### PR TITLE
Fix mold/all of decimals on Linux (CC1633)

### DIFF
--- a/src/include/reb-config.h
+++ b/src/include/reb-config.h
@@ -140,7 +140,6 @@ These are now obsolete (as of A107) and should be removed:
 
 #ifdef TO_LINUX					// Linux/Intel
 #define ENDIAN_LITTLE
-#define HAS_ECVT
 #define HAS_LONG_DOUBLE
 #endif
 


### PR DESCRIPTION
The results of mold/all for decimals on Linux are inconsistent with other platforms (Win32, OSX).

For example, on R3 2.101.0.4.4 (Linux):

```
>> mold/all 0.1
== "0.1"
```

Whereas on R3 2.100.111.3.1 (Win32):

```
>> mold/all 0.1
== "0.10000000000000001"
```

See [CureCode #1633](http://issue.cc/r3/1633)  for details.

As suggested by Ladislav Mecir in the CureCode discussion, undefining the `HAS_ECVT` config macro fixes this issue.
