### PR TITLE
Fix for a segfault, caused by writing to static memory in a signal handler

### DIFF
--- a/src/os/posix/dev-stdio.c
+++ b/src/os/posix/dev-stdio.c
@@ -78,10 +78,11 @@ void *Term_IO;
 #define FLUSH()		fflush(stdout)
 */
 
-
 static void Handle_Signal(int sig)
 {
-	Put_Str("[escape]");
+	char *buf = strdup("[escape]");
+	Put_Str(buf);
+	free(buf);
 	RL_Escape(0);
 }
 


### PR DESCRIPTION
How to reproduce the segfault: it can be reproduced 
on a Linux x64 build, by following these steps:
1. Start the interpreter (by itself, or by gdb if you want some additional information).
2. Press Ctrl-C
3. ==>The '[escape]' text will appear.
4. Press Enter.
5. ==>The interpreter crashes.

Here is an example reproduction with some debugging information about the segfault:
1. Starting a debugging session:

```
>>>$ gdb ./r3
>>>(gdb) r
>>>Starting program: /home/delian/Work/r3/make/r3
......
```
1. Press Ctrl-C to switch to the debugger, and emulate the signal which the r3 process will receive on a normal Ctrl-C:

```
>>>(gdb) signal SIGINT
>>>Continuing with signal SIGINT.
>>>[escape]
```
1. Here simply press 'Enter'

```
>>Program received signal SIGSEGV, Segmentation fault.
>>0x080b2aa6 in Fetch_Buf () at ../src/os/host-stdio.c:101
>>101             Std_IO_Req.data[len] = 0;
>>(gdb) bt
>>#0  0x080b2aa6 in Fetch_Buf () at ../src/os/host-stdio.c:101
>>#1  0x080b2b52 in Get_Str () at ../src/os/host-stdio.c:147
>>#2  0x080b1c09 in main (argc=1, argv=0xffffcf54) at ../src/os/host-main.c:183
```

After the fix is applied, the `Std_IO_Req.data[len] = 0` line will write to a fresh heap copy of the static string instead of the static string itself, thus avoiding the segfault.

I've tried to pass a global array to avoid the copy, but then the string `[escape]` becomes corrupted to `[` after the first Ctrl-C, and subsequently it shows just `[` if you press it again.
