### PR TITLE
Fix GCC compiler error: "lvalue required as increment operand"

### DIFF
--- a/src/core/s-make.c
+++ b/src/core/s-make.c
@@ -125,12 +125,13 @@
 {
 #ifdef OS_WIDE_CHAR
 	REBSER *dst;
-	if (Is_Wide((REBUNI*)src, len)) {
+	REBUNI *str = (REBUNI*)src;	
+	if (Is_Wide(str, len)) {
 		REBUNI *up;
 		dst = Make_Unicode(len);
 		SERIES_TAIL(dst) = len;
 		up = UNI_HEAD(dst);
-		while (len-- > 0) *up++ = *((REBUNI*)src)++;
+		while (len-- > 0) *up++ = *str++;
 		*up = 0;
 	}
 	else {
@@ -138,7 +139,7 @@
 		dst = Make_Binary(len);
 		SERIES_TAIL(dst) = len;
 		bp = BIN_HEAD(dst);
-		while (len-- > 0) *bp++ = (REBYTE)*((REBUNI*)src)++;
+		while (len-- > 0) *bp++ = (REBYTE)*str++;
 		*bp = 0;
 	}
 	return dst;


### PR DESCRIPTION
Cpyhre's GCC compile error fix, as originally submitted in pull request #22. The original message follows verbatim.

---

I made a fix to the GCC error when building under Windows:

```
gcc ../src/core/s-make.c -c -DTO_WIN32 -DREB_API -DUNICODE -O2 -I. -I../src/incl
ude/ -o objs/s-make.o
../src/core/s-make.c: In function 'Copy_OS_Str':
../src/core/s-make.c:133: error: lvalue required as increment operand
../src/core/s-make.c:141: error: lvalue required as increment operand
```

GCC version I'm using is:

```
C:\Users\cyphre>gcc -v
Using built-in specs.
Target: mingw32
Configured with: ../../gcc-4.4.1/configure --prefix=/mingw --build=mingw32 --ena
ble-languages=c,ada,c++,fortran,objc,obj-c++ --disable-nls --disable-win32-regis
try --enable-libgomp --enable-cxx-flags='-fno-function-sections -fno-data-sectio
ns' --disable-werror --enable-threads --disable-symvers --enable-version-specifi
c-runtime-libs --enable-fully-dynamic-string --with-pkgversion='TDM-2 mingw32' -
-enable-sjlj-exceptions --with-bugurl=http://www.tdragon.net/recentgcc/bugs.php
Thread model: win32
gcc version 4.4.1 (TDM-2 mingw32)
```

Please review the fix and if it looks ok to you, include in the main repository.
