### PR TITLE
Fix and improve build for Win32

### DIFF
--- a/src/include/reb-config.h
+++ b/src/include/reb-config.h
@@ -102,7 +102,9 @@ These are now obsolete (as of A107) and should be removed:
 #define INLINE __inline			// name used for it
 
 #ifdef THREADED
+#ifndef __MINGW32__
 #define THREAD __declspec(thread)
+#endif
 #endif
 
 // Used when we build REBOL as a DLL:

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -63,7 +63,7 @@ I= -I$(INCL) -I$S/include/
 TO_OS=	
 OS_ID=	
 RAPI_FLAGS=	
-HOST_FLAGS=	
+HOST_FLAGS=	-DREB_EXE
 RLIB_FLAGS=	
 
 # Flags for core and for host:

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -244,6 +244,10 @@ append plat-id os-plat/3
 ; Create TO-OSNAME to indicate target OS:
 to-def: join "TO_" uppercase copy os-name
 
+; Collect OS-specific host files:
+os-specific-objs: select fb to word! join "os-" os-base
+os-specific-dir: dirize to file! join %os/ os-base
+
 outdir: path-make
 make-dir outdir
 make-dir outdir/objs
@@ -349,13 +353,13 @@ macro++ RAPI_FLAGS compile-flags
 macro++ HOST_FLAGS make compile-flags [PIC: NCM: none]
 macro+  HOST_FLAGS compile-flags/f64 ; default for all
 
-if flag? +SC [remove find fb/os-posix 'host-readline.c]
+if flag? +SC [remove find fb/os-specific-objs 'host-readline.c]
 
 emit makefile-head
 emit ["OBJS =" tab]
 emit-obj-files fb/core
 emit ["HOST =" tab]
-emit-obj-files append copy fb/os fb/os-posix
+emit-obj-files append copy fb/os os-specific-objs
 emit makefile-link
 emit get pick [makefile-dyn makefile-so] os-plat/2 = 2
 emit {
@@ -366,7 +370,7 @@ b-boot.c: $(SRC)/boot/boot.r
 emit newline
 emit-file-deps fb/core
 emit-file-deps/dir fb/os %os/
-emit-file-deps/dir fb/os-posix %os/posix/
+emit-file-deps/dir os-specific-objs os-specific-dir
 
 ;print copy/part output 300 halt
 print ["Created:" outdir/makefile]

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -351,6 +351,7 @@ unless flag? -SP [ ; Use standard paths:
 	macro+ UP ".."
 	macro+ CD "./"
 ]
+if os-plat/2 = 3 [macro+ REBOL ">NUL:"] ; Temporary workaround for R3 on Win7.
 if flag? EXE [macro+ BIN_SUFFIX %.exe]
 macro++ CLIB linker-flags
 macro++ RAPI_FLAGS compile-flags

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -62,6 +62,7 @@ I= -I$(INCL) -I$S/include/
 
 TO_OS=	
 OS_ID=	
+BIN_SUFFIX=	
 RAPI_FLAGS=	
 HOST_FLAGS=	-DREB_EXE
 RLIB_FLAGS=	
@@ -75,11 +76,11 @@ CLIB=   -lm
 REBOL=	$(CD)r3-make -qs
 
 # For running tests, ship, build, etc.
-R3=	$(CD)r3 -qs
+R3=	$(CD)r3$(BIN_SUFFIX) -qs
 
 ### Build targets:
 top:
-	make r3
+	make r3$(BIN_SUFFIX)
 
 update:
 	-cd $(UP)/; cvs -q update src
@@ -93,9 +94,9 @@ clean:
 all:
 	make clean
 	make prep
-	make r3
+	make r3$(BIN_SUFFIX)
 	make lib
-	make host
+	make host$(BIN_SUFFIX)
 
 prep:
 	$(REBOL) $T/make-headers.r
@@ -108,16 +109,16 @@ prep:
 ### Post build actions
 purge:
 	-rm libr3.*
-	-rm host
+	-rm host$(BIN_SUFFIX)
 	make lib
-	make host
+	make host$(BIN_SUFFIX)
 
 test:
-	$(CP) r3 $(UP)/src/tests/
+	$(CP) r3$(BIN_SUFFIX) $(UP)/src/tests/
 	$(R3) $S/tests/test.r
 
 install:
-	sudo cp r3 /usr/local/bin
+	sudo cp r3$(BIN_SUFFIX) /usr/local/bin
 
 ship:
 	$(R3) $S/tools/upload.r
@@ -129,9 +130,9 @@ cln:
 	rm libr3.* r3.o
 
 check:
-	$(STRIP) -s -o r3.s r3
-	$(STRIP) -x -o r3.x r3
-	$(STRIP) -X -o r3.X r3
+	$(STRIP) -s -o r3.s r3$(BIN_SUFFIX)
+	$(STRIP) -x -o r3.x r3$(BIN_SUFFIX)
+	$(STRIP) -X -o r3.X r3$(BIN_SUFFIX)
 	ls -l r3*
 
 }
@@ -140,11 +141,11 @@ check:
 
 makefile-link: {
 # Directly linked r3 executable:
-r3:	objs $(OBJS) $(HOST)
-	$(CC) -o r3 $(OBJS) $(HOST) $(CLIB)
-	$(STRIP) r3
-	-$(NM) -a r3
-	ls -l r3
+r3$(BIN_SUFFIX):	objs $(OBJS) $(HOST)
+	$(CC) -o r3$(BIN_SUFFIX) $(OBJS) $(HOST) $(CLIB)
+	$(STRIP) r3$(BIN_SUFFIX)
+	-$(NM) -a r3$(BIN_SUFFIX)
+	ls -l r3$(BIN_SUFFIX)
 
 objs:
 	mkdir -p objs
@@ -163,11 +164,10 @@ libr3.so:	$(OBJS)
 	ls -l libr3.so
 
 # PUBLIC: Host using the shared lib:
-host:	$(HOST)
-	$(CC) -o host $(HOST) libr3.so $(CLIB)
-	$(STRIP) libr3.lib
-	$(STRIP) host
-	ls -l host
+host$(BIN_SUFFIX):	$(HOST)
+	$(CC) -o host$(BIN_SUFFIX) $(HOST) libr3.so $(CLIB)
+	$(STRIP) host$(BIN_SUFFIX)
+	ls -l host$(BIN_SUFFIX)
 	echo "export LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH"
 }
 
@@ -184,10 +184,10 @@ libr3.dylib:	$(OBJS)
 	ls -l libr3.dylib
 
 # PUBLIC: Host using the shared lib:
-host:	$(HOST)
-	$(CC) -o host $(HOST) libr3.dylib $(CLIB)
-	$(STRIP) host
-	ls -l host
+host$(BIN_SUFFIX):	$(HOST)
+	$(CC) -o host$(BIN_SUFFIX) $(HOST) libr3.dylib $(CLIB)
+	$(STRIP) host$(BIN_SUFFIX)
+	ls -l host$(BIN_SUFFIX)
 	echo "export LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH"
 }
 
@@ -348,6 +348,7 @@ unless flag? -SP [ ; Use standard paths:
 	macro+ UP ".."
 	macro+ CD "./"
 ]
+if flag? EXE [macro+ BIN_SUFFIX %.exe]
 macro++ CLIB linker-flags
 macro++ RAPI_FLAGS compile-flags
 macro++ HOST_FLAGS make compile-flags [PIC: NCM: none]

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -47,6 +47,8 @@ STRIP=	$(TOOLS)strip
 
 # CP allows different copy progs:
 CP=	
+# LS allows different ls progs:
+LS=	
 # UP - some systems do not use ../
 UP=	
 # CD - some systems do not use ./
@@ -133,7 +135,7 @@ check:
 	$(STRIP) -s -o r3.s r3$(BIN_SUFFIX)
 	$(STRIP) -x -o r3.x r3$(BIN_SUFFIX)
 	$(STRIP) -X -o r3.X r3$(BIN_SUFFIX)
-	ls -l r3*
+	$(LS) r3*
 
 }
 
@@ -145,7 +147,7 @@ r3$(BIN_SUFFIX):	objs $(OBJS) $(HOST)
 	$(CC) -o r3$(BIN_SUFFIX) $(OBJS) $(HOST) $(CLIB)
 	$(STRIP) r3$(BIN_SUFFIX)
 	-$(NM) -a r3$(BIN_SUFFIX)
-	ls -l r3$(BIN_SUFFIX)
+	$(LS) r3$(BIN_SUFFIX)
 
 objs:
 	mkdir -p objs
@@ -161,13 +163,13 @@ libr3.so:	$(OBJS)
 	$(STRIP) libr3.so
 	-$(NM) -D libr3.so
 	-$(NM) -a libr3.so | grep "Do_"
-	ls -l libr3.so
+	$(LS) libr3.so
 
 # PUBLIC: Host using the shared lib:
 host$(BIN_SUFFIX):	$(HOST)
 	$(CC) -o host$(BIN_SUFFIX) $(HOST) libr3.so $(CLIB)
 	$(STRIP) host$(BIN_SUFFIX)
-	ls -l host$(BIN_SUFFIX)
+	$(LS) host$(BIN_SUFFIX)
 	echo "export LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH"
 }
 
@@ -181,13 +183,13 @@ libr3.dylib:	$(OBJS)
 	$(STRIP) -x libr3.dylib
 	-$(NM) -D libr3.dylib
 	-$(NM) -a libr3.dylib | grep "Do_"
-	ls -l libr3.dylib
+	$(LS) libr3.dylib
 
 # PUBLIC: Host using the shared lib:
 host$(BIN_SUFFIX):	$(HOST)
 	$(CC) -o host$(BIN_SUFFIX) $(HOST) libr3.dylib $(CLIB)
 	$(STRIP) host$(BIN_SUFFIX)
-	ls -l host$(BIN_SUFFIX)
+	$(LS) host$(BIN_SUFFIX)
 	echo "export LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH"
 }
 
@@ -197,7 +199,7 @@ libr3.lib:	r3.o
 	ld -static -r -o libr3.lib r3.o
 	$(STRIP) libr3.lib
 	-$(NM) -a libr3.lib | grep "Do_"
-	ls -l libr3.lib
+	$(LS) libr3.lib
 }
 
 ;******************************************************************************
@@ -266,7 +268,7 @@ macro+: func [
 	'name
 	value
 ][
-	name: find find makefile-head join name "=" newline
+	name: find find/tail makefile-head join newline join name "=" newline
 	if name/-1 != space [name: insert name space]
 	insert name value
 ]
@@ -343,6 +345,7 @@ replace makefile-head "!date" now
 
 macro+ TO_OS to-def
 macro+ OS_ID os-plat
+macro+ LS pick ["dir" "ls -l"] flag? DIR
 macro+ CP pick [copy cp] flag? COP
 unless flag? -SP [ ; Use standard paths:
 	macro+ UP ".."

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -69,7 +69,7 @@ RLIB_FLAGS=
 # Flags for core and for host:
 RFLAGS= -c -D$(TO_OS) -DREB_API  $(RAPI_FLAGS) $I
 HFLAGS= -c -D$(TO_OS) -DREB_CORE $(HOST_FLAGS) $I
-CLIB=   -lc -lm
+CLIB=   -lm
 
 # REBOL builds various include files:
 REBOL=	$(CD)r3-make -qs

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -23,7 +23,7 @@ systems: [
 	[0.1.03 "amiga"      posix  [HID NPS +SC CMT COP -SP]]
 	[0.2.04 "osx"        posix  [+OS NCM]]			; no shared lib possible
 	[0.2.05 "osxi"       posix  [ARC +O1 NPS PIC NCM HID STX]]
-	[0.3.01 "win32"      win32  [+O2 UNI W32 WIN]]
+	[0.3.01 "win32"      win32  [+O2 UNI W32 WIN S4M]]
 	[0.4.02 "linux"      posix  [+O2 LDL ST1]]		; libc 2.3
 	[0.4.03 "linux"      posix  [+O2 HID LDL ST1]]	; libc 2.5
 	[0.4.04 "linux"      posix  [+O2 HID LDL ST1 M32]]	; libc 2.11
@@ -60,6 +60,7 @@ linker-flags: [
 	M32: "-m32"       ; use 32-bit memory model (Linux x64)
 	W32: "-lwsock32 -lcomdlg32"
 	WIN: "-mwindows"; build as Windows GUI binary
+	S4M: "-Wl,--stack=4194300"
 ]
 
 other-flags: [

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -23,7 +23,7 @@ systems: [
 	[0.1.03 "amiga"      posix  [HID NPS +SC CMT COP -SP]]
 	[0.2.04 "osx"        posix  [+OS NCM]]			; no shared lib possible
 	[0.2.05 "osxi"       posix  [ARC +O1 NPS PIC NCM HID STX]]
-	[0.3.01 "win32"      win32  [+O2 UNI W32]]
+	[0.3.01 "win32"      win32  [+O2 UNI W32 WIN]]
 	[0.4.02 "linux"      posix  [+O2 LDL ST1]]		; libc 2.3
 	[0.4.03 "linux"      posix  [+O2 HID LDL ST1]]	; libc 2.5
 	[0.4.04 "linux"      posix  [+O2 HID LDL ST1 M32]]	; libc 2.11
@@ -59,6 +59,7 @@ linker-flags: [
 	ARC: "-arch i386" ; x86 32 bit architecture (OSX)
 	M32: "-m32"       ; use 32-bit memory model (Linux x64)
 	W32: "-lwsock32 -lcomdlg32"
+	WIN: "-mwindows"; build as Windows GUI binary
 ]
 
 other-flags: [

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -23,7 +23,7 @@ systems: [
 	[0.1.03 "amiga"      posix  [HID NPS +SC CMT COP -SP]]
 	[0.2.04 "osx"        posix  [+OS NCM]]			; no shared lib possible
 	[0.2.05 "osxi"       posix  [ARC +O1 NPS PIC NCM HID STX]]
-	[0.3.01 "win32"      win32  [+O2 UNI W32 WIN S4M]]
+	[0.3.01 "win32"      win32  [+O2 UNI W32 WIN S4M EXE]]
 	[0.4.02 "linux"      posix  [+O2 LDL ST1]]		; libc 2.3
 	[0.4.03 "linux"      posix  [+O2 HID LDL ST1]]	; libc 2.5
 	[0.4.04 "linux"      posix  [+O2 HID LDL ST1 M32]]	; libc 2.11
@@ -71,6 +71,7 @@ other-flags: [
 	STX: "-x"
 	ST2: "-S -x -X"
 	CMT: "-R.comment"
+	EXE: ""		; use %.exe as binary file suffix
 ]
 
 config-system: func [

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -23,7 +23,7 @@ systems: [
 	[0.1.03 "amiga"      posix  [HID NPS +SC CMT COP -SP]]
 	[0.2.04 "osx"        posix  [+OS NCM]]			; no shared lib possible
 	[0.2.05 "osxi"       posix  [ARC +O1 NPS PIC NCM HID STX]]
-	[0.3.01 "win32"      win32  [+O2 UNI]]
+	[0.3.01 "win32"      win32  [+O2 UNI W32]]
 	[0.4.02 "linux"      posix  [+O2 LDL ST1]]		; libc 2.3
 	[0.4.03 "linux"      posix  [+O2 HID LDL ST1]]	; libc 2.5
 	[0.4.04 "linux"      posix  [+O2 HID LDL ST1 M32]]	; libc 2.11
@@ -58,6 +58,7 @@ linker-flags: [
 	LDL: "-ldl"     ; link with dynamic lib lib
 	ARC: "-arch i386" ; x86 32 bit architecture (OSX)
 	M32: "-m32"       ; use 32-bit memory model (Linux x64)
+	W32: "-lwsock32 -lcomdlg32"
 ]
 
 other-flags: [

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -23,7 +23,7 @@ systems: [
 	[0.1.03 "amiga"      posix  [HID NPS +SC CMT COP -SP]]
 	[0.2.04 "osx"        posix  [+OS NCM]]			; no shared lib possible
 	[0.2.05 "osxi"       posix  [ARC +O1 NPS PIC NCM HID STX]]
-	[0.3.01 "win32"      win32  [+O2 UNI W32 WIN S4M EXE]]
+	[0.3.01 "win32"      win32  [+O2 UNI W32 WIN S4M EXE DIR]]
 	[0.4.02 "linux"      posix  [+O2 LDL ST1]]		; libc 2.3
 	[0.4.03 "linux"      posix  [+O2 HID LDL ST1]]	; libc 2.5
 	[0.4.04 "linux"      posix  [+O2 HID LDL ST1 M32]]	; libc 2.11
@@ -67,6 +67,7 @@ other-flags: [
 	+SC: ""		; has smart console
 	-SP: ""		; non standard paths
 	COP: ""		; use COPY as cp program
+	DIR: ""		; use DIR as ls program
 	ST1: "-s"	; strip flags...
 	STX: "-x"
 	ST2: "-S -x -X"


### PR DESCRIPTION
Here's the first set of changes to the Win32 build, created in collaboration with Cyphre and Robert. A quick overview (without trying to reiterate the commit summaries too much):
- Disable `declspec(thread)` for MinGW
- Default to build with REB_EXE defined
- Drop `-lc` linking to libc (not needed on Linux, OSX; MinGW on Win32 barfs on this)
- Link against wsock32 and comdlg32
- Build sources from os/win32/ for Win32
- Build r3 as GUI binary (just like the official RT Alpha builds)
- Fix stack size allocated for the Win32 binaries
- Use .exe in name of Win32 executables
- Use DIR instead of LS on Win32 (makes us slightly more independent from the MinGW shell)
- Use r3-make with `>NUL:`, to avoid R3 crash in make on Win7

The commit messages have all the detail. Be sure to not miss the "files changed" tab, to get a full diff for all the changes (or just [append `.diff` to the pull request URL](https://github.com/rebol/r3/pull/28.diff) to get it as plain text).
