### PR TITLE
fixed pair! op/action bug

### DIFF
--- a/src/core/t-pair.c
+++ b/src/core/t-pair.c
@@ -200,6 +200,8 @@
 		else if (n == REB_DECIMAL || n == REB_PERCENT) {
 			x2 = y2 = (REBD32)VAL_DECIMAL(arg);
 		}
+		else
+			Trap_Math_Args(REB_PAIR, action);
 
 		switch (action) {
 


### PR DESCRIPTION
This fix sloves following types of bugs:

> > 0x0 + none
> > == 1.#QNANx1.#QNAN
> > 
> > 0x0 + "abc"
> > == 1.#QNANx1.#QNAN
> > 
> > 0x0 + 'abc
> > == 1.#QNANx1.#QNAN
