### PR TITLE
fixed PARSE tag bug

### DIFF
--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -518,10 +518,11 @@ bad_target:
 					i = Find_Str_Str(series, 0, index, series->tail, 1, ser, 0, ser->tail, HAS_CASE(parse));
 					if (i != NOT_FOUND && is_thru) i += ser->tail;
 				}
-				else
+				else {
 					i = Find_Str_Str(series, 0, index, series->tail, 1, VAL_SERIES(item), VAL_INDEX(item), VAL_LEN(item), HAS_CASE(parse));
+					if (is_thru) i += VAL_LEN(item);
+				}
 				if (i >= series->tail) i = NOT_FOUND;
-				else if (is_thru) i += VAL_LEN(item);
 			}
 			// #"A"
 			else if (IS_CHAR(item)) {


### PR DESCRIPTION
This fix should correct PARSE bug reported by Rebolek today.

Here is example of the bug:

```
>>  parse "<tag>string" [thru <tag> m: (probe m)]
"ing"
```

After applying the fix:

```
>>  parse "<tag>string" [thru <tag> m: (probe m)]
"string"
```

Carl, please crosscheck if the fix makes sense.
