### PR TITLE
Files beginning with .. are skipped (http://issue.cc/r3/1899)

### DIFF
--- a/src/os/posix/dev-file.c
+++ b/src/os/posix/dev-file.c
@@ -192,7 +192,7 @@ static int Get_File_Info(REBREQ *file)
 			return DR_DONE;
 		}
 		cp = d->d_name;
-	} while (cp[0] == '.' && (cp[1] == 0 || cp[1] == '.'));
+	} while (cp[0] == '.' && (cp[1] == 0 || (cp[1] == '.' && cp[2] == 0)));
 
 	file->modes = 0;
 	COPY_BYTES(file->file.path, cp, MAX_FILE_NAME);

--- a/src/os/win32/dev-file.c
+++ b/src/os/win32/dev-file.c
@@ -150,7 +150,7 @@ static BOOL Seek_File_64(REBREQ *file)
 	}
 
 	// Skip over the . and .. dir cases:
-	while (cp == 0 || (cp[0] == '.' && (cp[1] == 0 || cp[1] == '.'))) {
+	while (cp == 0 || (cp[0] == '.' && (cp[1] == 0 || (cp[1] == '.' && cp[2] == 0)))) {
 
 		// Read next file entry, or error:
 		if (!FindNextFile(h, &info)) {


### PR DESCRIPTION
Only the files . and .. are special in Posix and Windows; other files
starting with . or .. are considered normal. R3 was skipping all files
starting with .. when reading a directory. This fixes that.
