### PR TITLE
REQUEST-FILE/multi returning multiple files is missing the last / in the filenames

### DIFF
--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -666,12 +666,13 @@ chk_neg:
 	// First is a dir path or full file path:
 	str = start;
 	n = LEN_STR(str);
-	dir = To_REBOL_Path(str, n, -1, 0);
 
-	if (len == 1) {
+	if (len == 1) {  // First is full file path
+		dir = To_REBOL_Path(str, n, -1, 0);
 		Set_Series(REB_FILE, Append_Value(blk), dir);
 	}
-	else {
+	else {  // First is dir path for the rest of the files
+		dir = To_REBOL_Path(str, n, -1, TRUE);
 		str += n + 1; // next
 		len = dir->tail;
 		while (n = LEN_STR(str)) {


### PR DESCRIPTION
See http://issue.cc/r3/1891 for details. It looks like the path wasn't
getting a trailing / added to it when multiple files were selected, so
when the filenames were appended that / was missing.
