### PR TITLE
Prevent misunderstandings like http://issue.cc/r3/1913

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -651,7 +651,7 @@ transcode: native [
 	source [binary!] "Must be Unicode UTF-8 encoded"
 	/next "Translate next complete value (blocks as single value)"
 	/only "Translate only a single value (blocks dissected)"
-	/error "Do not throw errors - return error object as value"
+	/error "Do not throw errors - return error object as value in place"
 ]
 
 echo: native [


### PR DESCRIPTION
By design, TRANSCODE/error inserts the error, that it would otherwise
trigger, in the place where it would insert a value if there was no
error. This provides valuable context for the error, and can be used to
help in recovery of the transcoding process if you want to. This doc
string tweak makes that more clear so there will be less confusion about
this.
