### PR TITLE
Fix CC#1865: resolve/extend/only crash

### DIFF
--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -728,7 +728,7 @@
 		for (words = FRM_WORD(target, 1); NOT_END(words); words++)
 			if (binds[VAL_BIND_CANON(words)]) n--;
 		// Expand frame by the amount required:
-		if (n > 0) Expand_Frame(source, n, 0);
+		if (n > 0) Expand_Frame(target, n, 0);
 		else expand = 0;
 	}
 


### PR DESCRIPTION
For RESOLVE/extend, the source context was extended instead of the target context. This mistake can invalidate assumptions and lead to invalid memory accesses, and, in turn, to crashes.

Tested as working and not introducing regressions on Linux 4.4 and Win32 3.1 (using Wine).

CureCode Issue: http://issue.cc/r3/1865
