### PR TITLE
Fixed #1875 - random/only bug

### DIFF
--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -833,9 +833,9 @@ zero_blk:
 		if (D_REF(2)) Trap0(RE_BAD_REFINES); // seed
 		if (D_REF(4)) { // /only
 			if (index >= tail) goto is_none;
-			index += (REBCNT)Random_Int(D_REF(3)) % (tail - index);  // /secure
+			len = (REBCNT)Random_Int(D_REF(3)) % (tail - index);  // /secure
 			arg = D_ARG(2); // pass to pick
-			SET_INTEGER(arg, index+1);
+			SET_INTEGER(arg, len+1);
 			action = A_PICK;
 			goto repick;
 		}


### PR DESCRIPTION
The randomly calculated pick position was being added to the block index before being passed to pick.  This caused a pick past the end of the block.

Changed to only pass the pick position.
