### PR TITLE
Fix readline handling of Ctrl-D, Home and End keys on Linux

### DIFF
--- a/src/os/posix/host-readline.c
+++ b/src/os/posix/host-readline.c
@@ -509,6 +509,9 @@ static struct termios Term_Attrs;	// Initial settings, restored on exit
 		case 2:	// CTRL-B
 			Move_Cursor(term, -1);
 			break;
+		case 4:	// CTRL-D
+			Delete_Char(term, FALSE);
+			break;
 		case 5:	// CTRL-E
 			End_Line(term);
 			break;

--- a/src/os/posix/host-readline.c
+++ b/src/os/posix/host-readline.c
@@ -482,6 +482,12 @@ static struct termios Term_Attrs;	// Initial settings, restored on exit
 		}
 		else {
 			switch (*++cp) {
+			case 'H':	// home
+				Home_Line(term);
+				break;
+			case 'F':	// end
+				End_Line(term);
+				break;
 			default:
 				// Q: what other keys do we want to support ?!
 				WRITE_STR("[ESC]");

--- a/src/os/posix/host-readline.c
+++ b/src/os/posix/host-readline.c
@@ -369,6 +369,8 @@ static struct termios Term_Attrs;	// Initial settings, restored on exit
 {
 	int len;
 
+	if ( (term->pos == term->end) && back == 0) return; //Ctrl-D at EOL
+   
 	if (back) term->pos--;
 
 	len = 1 + term->end - term->pos;

--- a/src/os/posix/host-readline.c
+++ b/src/os/posix/host-readline.c
@@ -465,6 +465,14 @@ static struct termios Term_Attrs;	// Initial settings, restored on exit
 				Delete_Char(term, FALSE);
 				cp++; // remove ~
 				break;
+
+			case 'H':	// home
+				Home_Line(term);
+				break;
+			case 'F':	// end
+				End_Line(term);
+				break;
+
 			default:
 				WRITE_STR("[ESC]");
 				cp--;
@@ -472,12 +480,6 @@ static struct termios Term_Attrs;	// Initial settings, restored on exit
 		}
 		else {
 			switch (*++cp) {
-			case 'H':	// home
-				Home_Line(term);
-				break;
-			case 'F':	// end
-				End_Line(term);
-				break;
 			default:
 				// Q: what other keys do we want to support ?!
 				WRITE_STR("[ESC]");


### PR DESCRIPTION
Ctrl-D now does the same as Delete.
They both now delete the character below the cursor. 
When the cursor is at EOL, they do nothing, as is common in most readline based environments.

The separate Home and End keys, as well as the ones on the Numpad, now also work.
