### PR TITLE
Fix missing includes in posix/dev-stdio.c

### DIFF
--- a/src/os/posix/dev-stdio.c
+++ b/src/os/posix/dev-stdio.c
@@ -42,6 +42,8 @@
 #include <errno.h>
 #include <unistd.h>
 #include <signal.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "reb-host.h"
 #include "host-lib.h"


### PR DESCRIPTION
Commit 221d10cc forgot to add the necessary includes, which now results in compiler warnings: `free` requires `stdlib.h`, `strdup` requires `string.h`.
