### PR TITLE
Minor changes to build process for HaikuOS (POSIX binding, of course)

### DIFF
--- a/src/include/reb-config.h
+++ b/src/include/reb-config.h
@@ -136,7 +136,14 @@ These are now obsolete (as of A107) and should be removed:
 #define AGG_FREETYPE            //use freetype2 library for fonts by default
 #define FINITE finite
 #define INLINE
+
+#ifndef TO_HAIKU
+// Unsupported by gcc 2.95.3-haiku-121101
 #define API_EXPORT __attribute__((visibility("default")))
+#else
+#define API_EXPORT
+#endif 
+
 #define API_IMPORT
 #endif
 
@@ -160,6 +167,12 @@ These are now obsolete (as of A107) and should be removed:
 #ifdef TO_LINUX_MIPS
 #define ENDIAN_LITTLE
 #define HAS_LONG_DOUBLE
+#endif
+
+#ifdef TO_HAIKU					// same as Linux/Intel seems to work
+#define ENDIAN_LITTLE
+#define HAS_LONG_DOUBLE
+#define HAS_LOG10L
 #endif
 
 #ifdef TO_OSXI					// OSX/Intel

--- a/src/os/posix/dev-file.c
+++ b/src/os/posix/dev-file.c
@@ -46,31 +46,6 @@
 #include <dirent.h>
 #include <errno.h>
 
-// dirent.d_type is a BSD extension, actually not part of POSIX
-// alternate from: http://ports.haiku-files.org/wiki/CommonProblems
-#ifndef DT_DIR
-static int
-is_dir (const char *path, const char *name)
-{
-  int len1 = strlen(path);
-  int len2 = strlen(name);
-  struct stat st;
-
-  char pathname[len1 + 1 + len2 + 1 + 13];
-  strcpy (pathname, path);
-
-  /* Avoid UNC-path "//name" on Cygwin.  */
-  if (len1 > 0 && pathname[len1 - 1] != '/')
-    strcat (pathname, "/");
-
-  strcat (pathname, name);
-
-  if (stat (pathname, &st))
-    return 0;
-  return S_ISDIR (st.st_mode);
-}
-#endif
-
 #include "reb-host.h"
 #include "host-lib.h"
 
@@ -87,6 +62,31 @@ is_dir (const char *path, const char *name)
 **	Local Functions
 **
 ***********************************************************************/
+
+#ifndef DT_DIR
+// dirent.d_type is a BSD extension, actually not part of POSIX
+// reformatted from: http://ports.haiku-files.org/wiki/CommonProblems
+static int Is_Dir(const char *path, const char *name)
+{
+	int len1 = strlen(path);
+	int len2 = strlen(name);
+	struct stat st;
+
+	char pathname[len1 + 1 + len2 + 1 + 13];
+	strcpy(pathname, path);
+
+	/* Avoid UNC-path "//name" on Cygwin.  */
+	if (len1 > 0 && pathname[len1 - 1] != '/')
+		strcat(pathname, "/");
+
+	strcat(pathname, name);
+
+	if (stat(pathname, &st))
+		return 0;
+
+	return S_ISDIR(st.st_mode);
+}
+#endif
 
 static REBOOL Seek_File_64(REBREQ *file)
 {
@@ -230,7 +230,7 @@ static int Get_File_Info(REBREQ *file)
 	// file system call for determining directories.
 	if (d->d_type == DT_DIR) SET_FLAG(file->modes, RFM_DIR);
 #else
-	if (is_dir (dir->file.path, file->file.path)) SET_FLAG(file->modes, RFM_DIR);
+	if (Is_Dir(dir->file.path, file->file.path)) SET_FLAG(file->modes, RFM_DIR);
 #endif
 
 	// Line below DOES NOT WORK -- because we need full path.

--- a/src/os/posix/dev-file.c
+++ b/src/os/posix/dev-file.c
@@ -46,6 +46,31 @@
 #include <dirent.h>
 #include <errno.h>
 
+// dirent.d_type is a BSD extension, actually not part of POSIX
+// alternate from: http://ports.haiku-files.org/wiki/CommonProblems
+#ifndef DT_DIR
+static int
+is_dir (const char *path, const char *name)
+{
+  int len1 = strlen(path);
+  int len2 = strlen(name);
+  struct stat st;
+
+  char pathname[len1 + 1 + len2 + 1 + 13];
+  strcpy (pathname, path);
+
+  /* Avoid UNC-path "//name" on Cygwin.  */
+  if (len1 > 0 && pathname[len1 - 1] != '/')
+    strcat (pathname, "/");
+
+  strcat (pathname, name);
+
+  if (stat (pathname, &st))
+    return 0;
+  return S_ISDIR (st.st_mode);
+}
+#endif
+
 #include "reb-host.h"
 #include "host-lib.h"
 
@@ -197,12 +222,16 @@ static int Get_File_Info(REBREQ *file)
 	file->modes = 0;
 	COPY_BYTES(file->file.path, cp, MAX_FILE_NAME);
 
+#ifdef DT_DIR
 	// NOTE: not all posix filesystems support this (mainly
 	// the Linux and BSD support it.) If this fails to build, a
 	// different mechanism must be used. However, this is the
 	// most efficient, because it does not require a separate
 	// file system call for determining directories.
 	if (d->d_type == DT_DIR) SET_FLAG(file->modes, RFM_DIR);
+#else
+	if (is_dir (dir->file.path, file->file.path)) SET_FLAG(file->modes, RFM_DIR);
+#endif
 
 	// Line below DOES NOT WORK -- because we need full path.
 	//Get_File_Info(file); // updates modes, size, time

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -72,7 +72,7 @@ RLIB_FLAGS=
 # Flags for core and for host:
 RFLAGS= -c -D$(TO_OS) -DREB_API  $(RAPI_FLAGS) $I
 HFLAGS= -c -D$(TO_OS) -DREB_CORE $(HOST_FLAGS) $I
-CLIB=   -lm
+CLIB=
 
 # REBOL builds various include files:
 REBOL=	$(CD)r3-make -qs

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -20,18 +20,19 @@ REBOL [
 
 systems: [
 	[plat  os-name   os-base  build-flags]
-	[0.1.03 "amiga"      posix  [HID NPS +SC CMT COP -SP]]
-	[0.2.04 "osx"        posix  [+OS NCM]]			; no shared lib possible
-	[0.2.05 "osxi"       posix  [ARC +O1 NPS PIC NCM HID STX]]
-	[0.3.01 "win32"      win32  [+O2 UNI W32 WIN S4M EXE DIR]]
-	[0.4.02 "linux"      posix  [+O2 LDL ST1]]		; libc 2.3
-	[0.4.03 "linux"      posix  [+O2 HID LDL ST1]]	; libc 2.5
-	[0.4.04 "linux"      posix  [+O2 HID LDL ST1 M32]]	; libc 2.11
-	[0.4.10 "linux_ppc"  posix  [+O1 HID LDL ST1]]
-	[0.4.20 "linux_arm"  posix  [+O2 HID LDL ST1]]
-	[0.4.30 "linux_mips" posix  [+O2 HID LDL ST1]]  ; glibc does not need C++
-	[0.7.02 "freebsd"    posix  [+O1 C++ ST1]]
-	[0.9.04 "openbsd"    posix  [+O1 C++ ST1]]
+	[0.1.03 "amiga"      posix  [HID NPS +SC CMT COP -SP -LM]]
+	[0.2.04 "osx"        posix  [+OS NCM -LM]]			; no shared lib possible
+	[0.2.05 "osxi"       posix  [ARC +O1 NPS PIC NCM HID STX -LM]]
+	[0.3.01 "win32"      win32  [+O2 UNI W32 WIN S4M EXE DIR -LM]]
+	[0.4.02 "linux"      posix  [+O2 LDL ST1 -LM]]		; libc 2.3
+	[0.4.03 "linux"      posix  [+O2 HID LDL ST1 -LM]]	; libc 2.5
+	[0.4.04 "linux"      posix  [+O2 HID LDL ST1 M32 -LM]]	; libc 2.11
+	[0.4.10 "linux_ppc"  posix  [+O1 HID LDL ST1 -LM]]
+	[0.4.20 "linux_arm"  posix  [+O2 HID LDL ST1 -LM]]
+	[0.4.30 "linux_mips" posix  [+O2 HID LDL ST1 -LM]]  ; glibc does not need C++
+	[0.5.75 "haiku"      posix  [+O2 ST1 NWK]]
+	[0.7.02 "freebsd"    posix  [+O1 C++ ST1 -LM]]
+	[0.9.04 "openbsd"    posix  [+O1 C++ ST1 -LM]]
 ]
 
 compile-flags: [
@@ -61,6 +62,8 @@ linker-flags: [
 	W32: "-lwsock32 -lcomdlg32"
 	WIN: "-mwindows"; build as Windows GUI binary
 	S4M: "-Wl,--stack=4194300"
+	-LM: "-lm" ; HaikuOS has math in libroot, for instance
+	NWK: "-lnetwork" ; Needed by HaikuOS
 ]
 
 other-flags: [


### PR DESCRIPTION
These were the minimal changes required.  Bear in mind I've never used the OS before this.

I also put up an executable that can be used for bootstrap with OS_ID=0.5.75 _(Let no one say I don't have a sense of humor.)_

http://metaeducation.com/media/shared/haiku/r3-make

(or if you'd rather get it in a zip...)

http://metaeducation.com/media/shared/haiku/r3-make.zip

Place the r3-make in the `/make/` directory and mark it executable via `chmod +x r3-make`.

Then  `make make OS_ID=0.5.75`, `make prep`, and `make` generate another working executable for me on the [R1/Alpha 4.1 ISO](https://www.haiku-os.org/get-haiku) (in VirtualBox)--which comes with git preinstalled, even.

I'd like to write an article or make a screencast about it.  I think the Haiku community could be a sympathetic audience to Rebol's "small is beautiful" mission.  But I'd rather point people to the main repo and not some branch on my private fork, so I'll wait on the merge.

Tests look pretty reasonable.

![haiku-test](https://f.cloud.github.com/assets/20440/32023/f1282b7a-4fda-11e2-8577-012e4aec2c3c.png)
