### PR TITLE
Fix missing /local in make-boot.r

### DIFF
--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -206,7 +206,7 @@ binary-to-c: either system/version/4 = 3 [
 	]
 ][
 	; Other formats (Linux, OpenBSD, etc.):
-	func [comp-data /local out] [
+	func [comp-data /local out data] [
 		out: make string! 4 * (length? comp-data)
 		forall comp-data [
 			data: copy/part comp-data 16


### PR DESCRIPTION
Due to the missed /local, the global `data` is overwritten. Currently,
this only results in a weird informational message (compressed code
beeing much larger than the supposedly uncompressed code).

But it also result in the uncompressed original code becoming
unavailable after compression. This is a nuisance, if we want to emit
uncompressed code for whatever reason.
