### PR TITLE
Corrected mispelled word

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -134,7 +134,7 @@ tail: action [
 ]
 
 head?: action [
-	{Returns TRUE if a series is at its beginnint.}
+	{Returns TRUE if a series is at its beginning.}
 	series [series! gob! port!]
 ]
 


### PR DESCRIPTION
There is a typing error in **head?** definition.
I just corrected misspelled word in **head?**  definition:
from 
**beginnint**
to
**beginning**
