### PR TITLE
Fix a regression in PARSE for the THRU keyword

### DIFF
--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -520,7 +520,7 @@ bad_target:
 				}
 				else {
 					i = Find_Str_Str(series, 0, index, series->tail, 1, VAL_SERIES(item), VAL_INDEX(item), VAL_LEN(item), HAS_CASE(parse));
-					if (is_thru) i += VAL_LEN(item);
+					if (i != NOT_FOUND && is_thru) i += VAL_LEN(item);
 				}
 				if (i >= series->tail) i = NOT_FOUND;
 			}


### PR DESCRIPTION
Commit 44012cc1e7313f2fd3772e543f2f8b9096d90f9c (pull #34) introduced a regression to PARSE that may lead a failing THRU to incorrectly reset the parse position. This, in turn, leads to endless loops in PARSE. A testcase showing this regression is:

```
parse "123.123." [any [thru "123"]]
```

This same regression also caused an endless loop in the `make prep` step of the R3 build.

Technically, the earlier commit always incremented the match position with the number of characters for skipping a successful THRU, without checking if the THRU match itself was successful. For unsuccesful matches, `NOT_FOUND` is returned, which is defined as -1. Adding the THRU offset to this may result in a position that is again within bounds of the data to be parsed, thereby potentially initiating an endless loop.

This commit fixes the regression by adding an explicit check against NOT_FOUND to the increment condition.

The regression was originally noted by user "dt2" on Stack Overflow chat.
