### PR TITLE
two memcpy to memmove changes, fix use of uninitialized err value

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -1813,7 +1813,8 @@ push_arg:
 
 	// Copy values to prior location:
 	inew--;
-	memcpy(DS_ARG(1), DS_TOP-(inew-1), inew * sizeof(REBVAL));
+	// memory areas may overlap, so use memmove and not memcpy!
+	memmove(DS_ARG(1), DS_TOP-(inew-1), inew * sizeof(REBVAL));
 	DSP = DS_ARG_BASE + inew; // new TOS
 	//Dump_Block(DS_ARG(1), inew);
 	VAL_WORD_FRAME(DSF_WORD(DSF)) = VAL_FUNC_BODY(func_val);

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -417,6 +417,8 @@
 			if ((err = Check_Error(ds)) >= 0) break;
 			// else CONTINUE:
 			if (mode == 1) SET_FALSE(ds); // keep the value (for mode == 1)
+		} else {
+			err = 0; // prevent later test against uninitialized value
 		}
 
 		if (mode > 0) {
@@ -426,7 +428,8 @@
 			if (mode == 1) {  // remove-each
 				if (IS_FALSE(ds)) {
 					REBCNT wide = SERIES_WIDE(series);
-					memcpy(series->data + (windex * wide), series->data + (rindex * wide), (index - rindex) * wide);
+					// memory areas may overlap, so use memmove and not memcpy!
+					memmove(series->data + (windex * wide), series->data + (rindex * wide), (index - rindex) * wide);
 					windex += index - rindex;
 					// old: while (rindex < index) *BLK_SKIP(series, windex++) = *BLK_SKIP(series, rindex++);
 				}


### PR DESCRIPTION
Found via valgrind that overlapping areas of memory were being used with `memcpy` in two cases.  Technically [this is Undefined Behavior](http://bryanpendleton.blogspot.com/2010/11/memcpy-memmove-and-overlapping-regions.html).  Whether it causes any problems in practice will vary from platform to platform or optimizer to optimizer, but `memmove` is the right thing (if they indeed are supposed to be able to overlap!)

Also: there was a read on an unassigned variable indicating an error in `Loop_Each`.  I guessed 0 would be the right thing to use.

**UPDATE:** These three articles on "What every C programmer needs to know about undefined behavior" from LLVM should probably be required reading for anyone who's going to develop on the Rebol C sources: [Part One](http://blog.llvm.org/2011/05/what-every-c-programmer-should-know.html), [Part Two](http://blog.llvm.org/2011/05/what-every-c-programmer-should-know_14.html), [Part Three](http://blog.llvm.org/2011/05/what-every-c-programmer-should-know_21.html)
