### PR TITLE
Match  "uncased" parse in Check_Bit with !HAS_CASE(parse)

### DIFF
--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -213,7 +213,7 @@ void Print_Parse_Index(REBCNT type, REBVAL *rules, REBSER *series, REBCNT index)
 
 	// Do we match to a char set?
 	case REB_BITSET:
-		flags = Check_Bit(VAL_SERIES(item), GET_ANY_CHAR(series, index), HAS_CASE(parse));
+		flags = Check_Bit(VAL_SERIES(item), GET_ANY_CHAR(series, index), !HAS_CASE(parse));
 		index = flags ? index + 1 : NOT_FOUND;
 		break;
 /*


### PR DESCRIPTION
 This fixes [CureCode issue #1938](http://issue.cc/r3/1938)

The definition for [Check_Bit]() is:

```
REBFLG Check_Bit(REBSER *bset, REBCNT c, REBFLG uncased)

Check bit indicated. Returns TRUE if set.
If uncased is TRUE, try to match either upper or lower case.
```

However the call from PARSE when matching against a bitset passes in [HAS_CASE(parse)](https://github.com/rebol/r3/blob/master/src/core/u-parse.c#L216).  The `/case` refinement on parse indicates a desire to _pay attention_ to case, not to ignore it.  This led to the reverse of the desired behavior:

```
>> ab: charset "Ab"
== make bitset! #{00000000000000004000000020}

>> parse "AB" [2 ab]
== false

>> parse/case "AB" [2 ab]
== true
```

Inverting the condition corrects this.  It also fixes issues with parsing binary data...where `/case` is always implied (thus could _never_ be case-insensitive as written).
