### PR TITLE
Fix crash in evaluation of immediate operators (op! values)

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -880,6 +880,7 @@ eval_func2:
 	case ET_OPERATOR:
 		// An operator can be native or function, so its true evaluation
 		// datatype is stored in the extended flags part of the value.
+		if (!word) word = ROOT_NONAME;
 		if (DSP <= 0 || index == 0) Trap1(RE_NO_OP_ARG, word);
 		ftype = VAL_GET_EXT(value) - REB_NATIVE;
 		dsf = Push_Func(TRUE, block, index, VAL_WORD_SYM(word), value); // TOS has first arg


### PR DESCRIPTION
The `ET_OPERATOR` case in `Do_Next` potentially dereferences a null pointer in `word`.

For the regular case when an op! is evaluated indirectly via word lookup (as in `do [1 + 2]`), the `word` variable will is properly initialised during the lookup before entering the operator evaluation.

If, however, an op! is evaluated directly (e.g. `do reduce [1 :+ 2]`), `word` will still be initialised to `0` and the attempt to look up the name associated with the operator in VAL_WORD_SYM(word) will dereference a null pointer (which typically crashes the interpreter).

We fix this in analogue to the implementation for immediate functions, by also using the internal "-unnamed-" placeholder (`ROOT_NONAME`) for immediate operators.

This bug was found via static code analysis with the Clang Static Analyzer.

Fixes [CureCode bug 1934](http://issue.cc/r3/1934).
