### PR TITLE
Fix crash when reading dns:// without a hostname

### DIFF
--- a/src/core/p-dns.c
+++ b/src/core/p-dns.c
@@ -66,8 +66,7 @@
 
 		arg = Obj_Value(spec, STD_PORT_SPEC_NET_HOST);
 
-		if (Scan_Tuple(VAL_BIN(arg), strlen(VAL_BIN(arg)), &tmp)) { 
-		//if (IS_TUPLE(arg)) {
+		if (IS_TUPLE(arg) && Scan_Tuple(VAL_BIN(arg), strlen(VAL_BIN(arg)), &tmp)) {
 			SET_FLAG(sock->modes, RST_REVERSE);
 			memcpy(&sock->net.remote_ip, VAL_TUPLE(&tmp), 4);
 		}


### PR DESCRIPTION
Previously, `read dns://` crashed the interpreter. With this fix, a dns:// spec without a hostname (or IPv4 address) is considered invalid for READ access:

```
>> read dns://
** Access error: invalid spec or options: dns://
```

Fixes the crash reported in [CureCode issue #1935](http://issue.cc/r3/1935).
