### PR TITLE
Allow INDEX? of NONE!

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -172,13 +172,13 @@ at: action [
 
 index?: action [
 	{Returns the current position (index) of the series.}
-	series [none! series! gob! port!]
+	series [series! gob! port! none!]
 	/xy {Returns index as an XY pair offset}
 ]
 
 length?: action [
 	{Returns the length (from the current position for series.)}
-	series [none! series! port! map! tuple! bitset! object! gob! struct! any-word!]
+	series [series! port! map! tuple! bitset! object! gob! struct! any-word! none!]
 ]
 
 ;-- Series Extraction

--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -172,7 +172,7 @@ at: action [
 
 index?: action [
 	{Returns the current position (index) of the series.}
-	series [series! gob! port!]
+	series [none! series! gob! port!]
 	/xy {Returns index as an XY pair offset}
 ]
 

--- a/src/core/t-none.c
+++ b/src/core/t-none.c
@@ -73,6 +73,7 @@
 	case A_TAILQ:
 		if (IS_NONE(val)) return R_TRUE;
 		goto trap_it;
+	case A_INDEXQ:
 	case A_LENGTHQ:
 		if (IS_NONE(val)) return R_NONE;
 		goto trap_it;

--- a/src/core/t-none.c
+++ b/src/core/t-none.c
@@ -75,8 +75,6 @@
 		goto trap_it;
 	case A_INDEXQ:
 	case A_LENGTHQ:
-		if (IS_NONE(val)) return R_NONE;
-		goto trap_it;
 	case A_SELECT:
 	case A_FIND:
 	case A_REMOVE:


### PR DESCRIPTION
This pull request primarily makes INDEX? "NONE-transparent", in line with the already none-transparent EMPTY? and LENGTH?:

```
>> index? none
== none
```

This implements [CureCode wish #1611](http://issue.cc/r3/1611).

Seeing as this was already once marked as "built" in CC before (but then later found to be not actually implemented), I assume this behaviour was actually intended to be implemented.

Aside from the INDEX? feature itself, the second commit removes some redundant code encountered while implementing the feature.
