### PR TITLE
Allow NEW-LINE and NEW-LINE? to accept PAREN! series

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -622,17 +622,17 @@ form: native [
 ]
 
 new-line: native [
-	{Sets or clears the new-line marker within a block.}
-	block [block!] {Position in block to change marker (modified)}
+	{Sets or clears the new-line marker within a block or paren.}
+	position [block! paren!] {Position to change marker (modified)}
 	value {Set TRUE for newline}
-	/all {Set/clear marker to end of block}
-	/skip {Set/clear marker periodically to the end of the block}
+	/all {Set/clear marker to end of series}
+	/skip {Set/clear marker periodically to the end of the series}
 	size [integer!]
 ]
 
 new-line?: native [
-	{Returns the state of the new-line marker within a block.}
-	block [block!] {Position in block to check marker}
+	{Returns the state of the new-line marker within a block or paren.}
+	position [block! paren!] {Position to check marker}
 ]
 
 to-local-file: native [


### PR DESCRIPTION
_This fixes [CureCode Issue 1940](http://curecode.org/rebol3/ticket.rsp?id=1940)_

On accident, I discovered that PAREN! preserves and molds newline behavior just like BLOCK! does...but unlike BLOCK! it did not offer the option to get or set those newline markers.

I suspected it would probably "just work" if the natives weren't defined to only accept BLOCK!.  So I just added PAREN! to the accepted types, and the suspicion appears to be correct.

I've not thought through whether newline markers make sense for PATH! etc.  I hope they don't.  But they certainly seem sensible for PAREN!, for instance in `parse` where they may (like blocks) contain many lines of code.

The test suite should probably contain something that sets newline markers and makes sure it gets the same answer back, stuff like:

```
>> foo: quote (a b c)
>> assert [false = new-line? next foo]
>> new-line next foo true
>> assert [true = new-line? next foo]
```
