### PR TITLE
Fix value returned by SELECT with a series argument

### DIFF
--- a/src/core/t-block.c
+++ b/src/core/t-block.c
@@ -726,7 +726,7 @@ zero_blk:
 			VAL_INDEX(value) = ret;
 		}
 		else {
-			ret++;
+			ret += len;
 			if (ret >= (REBCNT)tail) goto is_none;
 			value = BLK_SKIP(ser, ret);
 		}


### PR DESCRIPTION
Currently SELECT ignores what type of value was used for selection, and always returns the second value from the start of the match. This behaviour is correct when selecting with atomic values:

```
>> select [1 2 3 4] 1
== 2
```

But breaks when selecting with compound values:

```
>> select [1 2 3 4] [1 2]
== 2  ; Expected: 3

>> select "1234" "12"
== #"2"  ; Expected: #"3"
```

This commit fixes the incorrect calculation of the offset of the value to be returned by taking the length of the match value into account.

This fixes [CureCode issue 1936](http://issue.cc/r3/1936).
