### PR TITLE
Trim that bug! (src/core/s-trim.c)

### DIFF
--- a/src/core/s-trim.c
+++ b/src/core/s-trim.c
@@ -239,8 +239,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 			}
 			else if (uc == LF) {
 				outside = TRUE;
-				if (left) out = left;
-				left = 0;
+				if (left) out = left, left = 0;
 			}
 			else {
 				outside = FALSE;

--- a/src/core/s-trim.c
+++ b/src/core/s-trim.c
@@ -204,7 +204,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 ***********************************************************************/
 {
 	REBCNT out = index;
-	REBOOL alf = FALSE; // append line feed
+	REBOOL append_line_feed = FALSE;
 	REBUNI uc;
 
 	// Skip head lines if required:
@@ -219,7 +219,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 	if (t || !h) {
 		for (; index < tail; --tail) {
 			uc = GET_ANY_CHAR(ser, tail -1);
-			if (uc == LF) alf = TRUE;
+			if (uc == LF) append_line_feed = TRUE;
 			if (!IS_WHITE(uc)) break;
 		}
 	}
@@ -259,7 +259,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 	}
 
 	// Append line feed if necessary
-	if (alf && !t) {
+	if (append_line_feed && !t) {
 		SET_ANY_CHAR(ser, out, LF);
 		++out;
 	}

--- a/src/core/s-trim.c
+++ b/src/core/s-trim.c
@@ -230,9 +230,9 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 		REBCNT left = 0; // index of leftmost space (in output)
 
 		for (; index < tail; ++index) {
-			
+
 			uc = GET_ANY_CHAR(ser, index);
-			
+
 			if (IS_SPACE(uc)) {
 				if (outside) continue;
 				if (!left) left = out;

--- a/src/core/s-trim.c
+++ b/src/core/s-trim.c
@@ -209,7 +209,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 
 	// Skip head lines if required:
 	if (h || !t) {
-		for (; index < tail; ++index) {
+		for (; index < tail; index++) {
 			uc = GET_ANY_CHAR(ser, index);
 			if (!IS_WHITE(uc)) break;
 		}
@@ -247,14 +247,14 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 			}
 			
 			SET_ANY_CHAR(ser, out, uc);
-			++out;
+			out++;
 		}
 	}
 	else {
-		for (; index < tail; ++index) {
+		for (; index < tail; index++) {
 			uc = GET_ANY_CHAR(ser, index);
 			SET_ANY_CHAR(ser, out, uc);
-			++out;
+			out++;
 		}
 	}
 

--- a/src/core/s-trim.c
+++ b/src/core/s-trim.c
@@ -196,14 +196,10 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 
 /***********************************************************************
 **
-*/	static void trim_head_tail(REBSER *ser, REBCNT index, REBCNT tail, REBFLG const H, REBFLG const T)
+*/	static void trim_head_tail(REBSER *ser, REBCNT index, REBCNT tail, REBFLG h, REBFLG t)
 /*
 **		Trim from head and tail of each line, trim any leading or
 **		trailing lines as well, leaving one at the end if present
-**
-**	2012.02.02 CCX: Fixed the trim bug. Changed some var names and
-**		the function declaration to make easier to understand the
-**		algorithm.
 **
 ***********************************************************************/
 {
@@ -212,7 +208,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 	REBUNI uc;
 
 	// Skip head lines if required:
-	if (H || !T) {
+	if (h || !t) {
 		for (; index < tail; ++index) {
 			uc = GET_ANY_CHAR(ser, index);
 			if (!IS_WHITE(uc)) break;
@@ -220,7 +216,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 	}
 	
 	// Skip tail lines if required:
-	if (T || !H) {
+	if (t || !h) {
 		for (; index < tail; --tail) {
 			uc = GET_ANY_CHAR(ser, tail -1);
 			if (uc == LF) alf = TRUE;
@@ -229,7 +225,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 	}
 	
 	// Trim head and tail of innner lines if required:
-	if (!H && !T) {
+	if (!h && !t) {
 		REBOOL outside = FALSE; // inside an inner line
 		REBCNT left = 0; // index of leftmost space (in output)
 		
@@ -264,7 +260,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 	}
 
 	// Append line feed if necessary
-	if (alf && !T) {
+	if (alf && !t) {
 		SET_ANY_CHAR(ser, out, LF);
 		++out;
 	}

--- a/src/core/s-trim.c
+++ b/src/core/s-trim.c
@@ -217,7 +217,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 
 	// Skip tail lines if required:
 	if (t || !h) {
-		for (; index < tail; --tail) {
+		for (; index < tail; tail--) {
 			uc = GET_ANY_CHAR(ser, tail -1);
 			if (uc == LF) append_line_feed = TRUE;
 			if (!IS_WHITE(uc)) break;
@@ -229,7 +229,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 		REBOOL outside = FALSE; // inside an inner line
 		REBCNT left = 0; // index of leftmost space (in output)
 
-		for (; index < tail; ++index) {
+		for (; index < tail; index++) {
 
 			uc = GET_ANY_CHAR(ser, index);
 
@@ -261,7 +261,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 	// Append line feed if necessary
 	if (append_line_feed && !t) {
 		SET_ANY_CHAR(ser, out, LF);
-		++out;
+		out++;
 	}
 
 	SET_ANY_CHAR(ser, out, 0);

--- a/src/core/s-trim.c
+++ b/src/core/s-trim.c
@@ -214,7 +214,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 			if (!IS_WHITE(uc)) break;
 		}
 	}
-	
+
 	// Skip tail lines if required:
 	if (t || !h) {
 		for (; index < tail; --tail) {
@@ -223,12 +223,12 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 			if (!IS_WHITE(uc)) break;
 		}
 	}
-	
+
 	// Trim head and tail of innner lines if required:
 	if (!h && !t) {
 		REBOOL outside = FALSE; // inside an inner line
 		REBCNT left = 0; // index of leftmost space (in output)
-		
+
 		for (; index < tail; ++index) {
 			
 			uc = GET_ANY_CHAR(ser, index);
@@ -245,7 +245,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 				outside = FALSE;
 				left = 0;
 			}
-			
+
 			SET_ANY_CHAR(ser, out, uc);
 			out++;
 		}
@@ -263,7 +263,7 @@ static REBFLG find_in_uni(REBUNI *up, REBINT len, REBUNI c)
 		SET_ANY_CHAR(ser, out, LF);
 		++out;
 	}
-	
+
 	SET_ANY_CHAR(ser, out, 0);
 	SERIES_TAIL(ser) = out;
 }


### PR DESCRIPTION
2013.02.02 by CCX

```
>> trim "  x ^/"
== "x x^/"
```

Fixed that trim bug, found in `trim_head_tail()`. Changed some var
names to make the algorithm easier to understand. `head` and `tail`
are now trimmed first because its simpler this way.

First time I ever use github...
