### PR TITLE
Fix crash when accessing an empty but hashed map

### DIFF
--- a/src/core/t-map.c
+++ b/src/core/t-map.c
@@ -118,9 +118,9 @@
 	if (!hash) Trap_Type(key);
 
 	// Determine skip and first index:
-	skip  = (hash & 0x0000FFFF) % len;
+	skip  = (len == 0) ? 0 : (hash & 0x0000FFFF) % len;
 	if (skip == 0) skip = 1;
-	hash = (hash & 0x00FFFF00) % len;
+	hash = (len == 0) ? 0 : (hash & 0x00FFFF00) % len;
 
 	// Scan hash table for match:
 	hashes = (REBCNT*)hser->data;


### PR DESCRIPTION
A `map!` internally switches to a hashed implementation if the map holds more than a given number of items. If a map becomes empty again after having switched over to hashing, lookups on the empty map lead to a division by zero (in modular arithmetic), crashing the interpreter.

This commit fixes the division by zero crash by side-stepping modular arithmetic for the special case of an empty map.

The problem was originally identified by user HostileFork on Stack Overflow chat.

Fixes [CureCode issue #1930](http://issue.cc/r3/1929).
