### PR TITLE
bug#1955

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -42,7 +42,7 @@ Syntax: [
 	no-header:          [{script is missing a REBOL header:} :arg1]
 	bad-header:         [{script header is not valid:} :arg1]
 	bad-checksum:       [{script checksum failed:} :arg1]
-	malconstruct:       [{invalid constructor:} :arg1]
+	malconstruct:       [{invalid construction spec:} :arg1]
 	bad-char:           [{invalid character in:} :arg1]
 	needs:              [{this script needs} :arg1 :arg2 {or better to run correctly}]
 ]

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -612,7 +612,7 @@ mold: native [
 	{Converts a value to a REBOL-readable string.}
 	value [any-type!] {The value to mold}
 	/only {For a block value, mold only its contents, no outer []}
-	/all  {Mold in serialized format}
+	/all  {Use construction syntax}
 	/flat {No indentation}
 ]
 


### PR DESCRIPTION
Hostile Fork, Brian Hawley and I are proposing to use the notion of "construction syntax", "construction" or "construction spec" for #[...] like syntax elements.

Reasons:
- constructor (MAKE or something) is actually the part missing in construction specs
- the "serialized syntax" is not appropriate either since it is just a redundant and pleonastic equivalent of "syntax"
