### PR TITLE
bug#1957 corr, FIRST+ help strings updated

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -837,8 +837,8 @@ shift: native [
 ]
 
 first+: native [
-	{Return FIRST of series, and increment the series index.}
-	'word [word!] "Word must be a series"
+	{Return the FIRST of a series then increment the series index.}
+	'word [word!] "Word must refer to a series"
 ]
 
 stack: native [


### PR DESCRIPTION
The WORD parameter help string is incompatible with other similar argument help strings (FORSKIP).
