### PR TITLE
bug#1958, BIND and UNBIND help strings corrected

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -343,18 +343,18 @@ while: native [
 
 bind: native [
 	{Binds words to the specified context.}
-	word [block! any-word!] {A word or block of words (modified) (returned)}
+	word [block! any-word!] {A word or block (modified) (returned)}
 	context [any-word! any-object!] {A reference to the target context}
-	/copy {Deep copy block before binding it}
+	/copy {Bind and return a deep copy of a block, don't modify original}
 	/only {Bind only first block (not deep)}
 	/new {Add to context any new words found}
 	/set {Add to context any new set-words found}
 ]
 
 unbind: native [
-	{Unbinds words from context. (Modifies)}
-	word [block! any-word!] {A word or block of words (modified) (returned)}
-	/deep "Include nested blocks"
+	{Unbinds words from context.}
+	word [block! any-word!] {A word or block (modified) (returned)}
+	/deep "Process nested blocks"
 ]
 
 bound?: native [


### PR DESCRIPTION
When the BIND (or UNBIND) argument is a block it is not required for it to contain (just) words.
