### PR TITLE
Fix parse thru end

### DIFF
--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -522,7 +522,6 @@ bad_target:
 					i = Find_Str_Str(series, 0, index, series->tail, 1, VAL_SERIES(item), VAL_INDEX(item), VAL_LEN(item), HAS_CASE(parse));
 					if (i != NOT_FOUND && is_thru) i += VAL_LEN(item);
 				}
-				if (i >= series->tail) i = NOT_FOUND;
 			}
 			// #"A"
 			else if (IS_CHAR(item)) {

--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -506,8 +506,7 @@ bad_target:
 			}
 			///i = Find_Value(series, index, tail-index, item, 1, (REBOOL)(PF_CASE & flags), FALSE, 1);
 			i = Find_Block(series, index, series->tail, item, 1, HAS_CASE(parse)?AM_FIND_CASE:0, 1);
-			if (i >= series->tail) i = NOT_FOUND;
-			else if (is_thru) i++;
+			if (i != NOT_FOUND && is_thru) i++;
 		}
 		else {
 			// "str"


### PR DESCRIPTION
Commit 44012cc introduced a regression that causes THRU rules to fail when it matches to the end of input. A simple test case illustrating the regression:

```
>> parse "abcd" [thru "d"]
== false  ;; Expected: true
```

The regression was originally reported by Boleslav Brezovsky on AltME.

This fixes [CureCode issue #1959](http://issue.cc/r3/1959).
