### PR TITLE
Fix PARSE `THRU integer` operation

### DIFF
--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -486,7 +486,7 @@ bad_target:
 
 	// TO a specific index position.
 	if (IS_INTEGER(item)) {
-		i = (REBCNT)Int32(item) - 1;
+		i = (REBCNT)Int32(item) - (is_thru ? 0 : 1);
 		if (i > series->tail) i = series->tail;
 	}
 	// END


### PR DESCRIPTION
PARSE's `TO integer` operation positions "at" the given index. In line with how PARSE's TO/THRU relate otherwise, `THRU integer` should therefore move to the position "next" to the given index:

```
>> parse "abcd" [to 2 (comment {Positions to "bcd".}) "bcd"]
== true

>> parse "abcd" [thru 2 (comment {Should position to "cd".}) "cd"]
== false  ;; Expected: true
```

This commit adds the missing handling for distinguishing THRU from TO in the case handling `TO/THRU integer` operations.

This fixes [CureCode issue #1965](http://issue.cc/r3/1965).
