### PR TITLE
DECOMPRESS/GZIP fix

### DIFF
--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -292,7 +292,7 @@ static struct digest {
 
 	len = Partial1(D_ARG(1), D_ARG(3));
 
-	if (D_REF(4)) limit = Int32s(D_ARG(5), 1);
+	if (D_REF(5)) limit = Int32s(D_ARG(6), 1); // /limit size
 	
 	Set_Binary(D_RET, Decompress(VAL_SERIES(arg), VAL_INDEX(arg), len, limit, D_REF(4))); // /gzip
 

--- a/src/core/s-crc.c
+++ b/src/core/s-crc.c
@@ -374,8 +374,8 @@ static void Make_CRC32_Table(void) {
 	}
 }
 
-static unsigned long Update_CRC32(u32 crc, REBYTE *buf, int len) {
-	u32 c = crc;
+REBCNT Update_CRC32(u32 crc, REBYTE *buf, int len) {
+	u32 c = ~crc;
 	int n;
 
 	if(!crc32_table) Make_CRC32_Table();
@@ -383,7 +383,7 @@ static unsigned long Update_CRC32(u32 crc, REBYTE *buf, int len) {
 	for(n = 0; n < len; n++)
 		c = crc32_table[(c^buf[n])&0xff]^(c>>8);
 
-	return c;
+	return ~c;
 }
 
 /***********************************************************************
@@ -392,7 +392,7 @@ static unsigned long Update_CRC32(u32 crc, REBYTE *buf, int len) {
 /*
 ***********************************************************************/
 {
-	return Update_CRC32(0xffffffffL, buf, len) ^ 0xffffffffL;
+	return Update_CRC32(0x00000000L, buf, len);
 }
 
 

--- a/src/core/u-zlib.c
+++ b/src/core/u-zlib.c
@@ -48,9 +48,9 @@ uLong ZEXPORT adler32(adler, buf, len)
 uLong crc32(uLong num, const Bytef *buf, uInt len)
 {
 #ifndef CRC_DEFINED
-	extern CRC32(unsigned char *, uInt);
+	extern uLong Update_CRC32(uLong, unsigned char *, uInt);
 #endif
-	return num + CRC32((unsigned char *)buf, len);
+	return (len == 0) ? num : Update_CRC32(num, (unsigned char *)buf, len);
 }
 
 ///////////////////////////////////////////
@@ -364,7 +364,7 @@ int ZEXPORT deflateReset (strm)
         s->noheader = 0; /* was set to -1 by deflate(..., Z_FINISH); */
     }
     s->status = s->noheader ? BUSY_STATE : INIT_STATE;
-    strm->adler = 1;
+    strm->adler = (strm->checksum == crc32) ? 0L : 1L;
     s->last_flush = Z_NO_FLUSH;
 
     _tr_init(s);
@@ -456,7 +456,7 @@ int ZEXPORT deflate (strm, flush)
 	    putShortMSB(s, (uInt)(strm->adler >> 16));
 	    putShortMSB(s, (uInt)(strm->adler & 0xffff));
 	}
-	strm->adler = 1L;
+	strm->adler = (strm->checksum == crc32) ? 0L : 1L;
     }
 
     /* Flush as much pending output as possible */


### PR DESCRIPTION
changes details:
-fixed refinement/arg bug in DECOMPRESS
-fixed CRC32 calculation/verification in ZLIB code in DECOMPRESS/GZIP mode

Carl, maybe it would be better to change the /GZIP refinement to /CRC32 ? What do you think?
I think it is better as the feature is not fully compatible with GZIP format but it just uses different checksum type (instead of the default adler-32)
We can always write the higher-level formats (ZIP, GZIP etc.) in REBOL instead of hardcoding into the native code.
