### PR TITLE
Implement BROWSE on Mac OS X.

### DIFF
--- a/src/os/posix/host-lib.c
+++ b/src/os/posix/host-lib.c
@@ -54,6 +54,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <time.h>
 #include <string.h>
 
@@ -595,17 +596,23 @@ static void *Task_Ready;
 
 static int Try_Browser(char *browser, REBCHR *url)
 {
-	REBCHR *cmd = MAKE_STR(LEN_STR(browser) + LEN_STR(url) + 10);
-	int result;
+	pid_t pid;
+	int result, status;
 
-	// A temporary solution -- for some versions...
-	strcpy(cmd, browser);
-	strcat(cmd, " \"");
-	strcat(cmd, url);
-	strcat(cmd, "\"");
-	result = (system(cmd) == 0);
-	// printf("result: %d\n", result);
-	free(cmd);
+	switch (pid = fork()) {
+		case -1:
+			result = FALSE;
+			break;
+		case 0:
+			execlp(browser, browser, url, NULL);
+			exit(1);
+			break;
+		default:
+			waitpid(pid, &status, WUNTRACED);
+			result = WIFEXITED(status)
+					&& (WEXITSTATUS(status) == 0);
+	}
+
 	return result;
 }
 

--- a/src/os/posix/host-lib.c
+++ b/src/os/posix/host-lib.c
@@ -615,8 +615,14 @@ static int Try_Browser(char *browser, REBCHR *url)
 /*
 ***********************************************************************/
 {
-	if (Try_Browser("xdg-open", url) || Try_Browser("x-www-browser", url))
-		return TRUE;
+	if (
+#if defined(TO_OSX) || defined(TO_OSXI)
+		Try_Browser("/usr/bin/open", url)
+#else
+		Try_Browser("xdg-open", url)
+		|| Try_Browser("x-www-browser", url)
+#endif
+	) return TRUE;
 	return FALSE;
 }
 


### PR DESCRIPTION
This request consists of two changes, addressing Cure Code ticket #1992 ( http://curecode.org/rebol3/ticket.rsp?id=1992 ):
1.  The system(3) call in `Try_Browser` has been replaced with `fork(2)` and `execlp(3)`. As such, the call string needn't be constructed and failed calls no longer print their output to the console.
2.  On OS X, `OS_Browse` only attempts to use `/usr/bin/open`; on other POSIX platforms, "xdg-open" and "x-www-browser" are used as before.
