### PR TITLE
BROWSE: Return R_UNSET rather than R_NONE.

### DIFF
--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -506,14 +506,16 @@ chk_neg:
 
 	Check_Security(SYM_BROWSE, POL_EXEC, arg);
 
-	if (!IS_NONE(arg))
-		url = Val_Str_To_OS(arg);
+	if (IS_NONE(arg))
+		return R_UNSET;
+
+	url = Val_Str_To_OS(arg);
 
 	r = OS_BROWSE(url, 0);
 
 	if (r == 0) Trap1(RE_CALL_FAIL, Make_OS_Error());
 
-	return R_NONE;
+	return R_UNSET;
 }
 
 


### PR DESCRIPTION
Following discussion on AltMe, modify `browse` to return `R_UNSET` rather than `R_NONE`.

In addition, handle the `none` case correctly (return early). At present, browsing `none`yields a SEGFAULT; this commit addresses Cure Code ticket #1991 ( http://curecode.org/rebol3/ticket.rsp?id=1991 ).
