### PR TITLE
Round decimal division of tuple elements.

### DIFF
--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -232,7 +232,7 @@
 			case A_DIVIDE:
 				if (IS_DECIMAL(arg) || IS_PERCENT(arg)) {
 					if (dec == 0.0) Trap0(RE_ZERO_DIVIDE);
-					v=(REBINT)(v/dec);
+					v=(REBINT)round(v/dec);
 				} else {
 					if (a == 0) Trap0(RE_ZERO_DIVIDE);
 					v /= a;

--- a/src/core/t-tuple.c
+++ b/src/core/t-tuple.c
@@ -232,7 +232,7 @@
 			case A_DIVIDE:
 				if (IS_DECIMAL(arg) || IS_PERCENT(arg)) {
 					if (dec == 0.0) Trap0(RE_ZERO_DIVIDE);
-					v=(REBINT)round(v/dec);
+					v=(REBINT)Round_Dec(v/dec, 0, 1.0);
 				} else {
 					if (a == 0) Trap0(RE_ZERO_DIVIDE);
 					v /= a;


### PR DESCRIPTION
(These commits address [Cure Code ticket #1974](http://issue.cc/r3/1974).)

When performing tuple division, the floating point representation of decimal divisors may yield surprising results.  For example, the following expression

```
>> 1.1.1 / 0.1
```

can return `9.9.9` or `10.10.10` depending on the host platform.

To address such discrepancies, call `Round_Dec` with the default rounding strategy (halves round up away from zero) before casting the result of tuple element division to a `REBINT`; this should improve cross-platform consistency.

Note that this change means that the following expressions both evaluate to `10.10.10`:

```
>> 1.1.1 / 0.1
>> 1.1.1 / 0.101
```
