### PR TITLE
Prevent word duplication when appending to an object

### DIFF
--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -97,12 +97,11 @@ static void Append_Obj(REBSER *obj, REBVAL *arg)
 
 	// Add absent words to frame and update values
 	for (arg = VAL_BLK_DATA(start); NOT_END(arg); arg += 2) {
-		if (!Bind_Word(obj, arg)) {
+		if (i = Find_Word_Index(obj, VAL_WORD_SYM(arg), TRUE)) {
+			val = FRM_VALUE(obj, i);
+		} else {
 			i = BLK_LEN(obj);
 			val = Append_Frame(obj, arg, 0); // word not in frame, so add it.
-		} else {
-			i = Find_Word_Index(obj, VAL_WORD_SYM(arg), TRUE);
-			val = FRM_VALUE(obj, i);
 		}
 
 		if (GET_FLAGS(VAL_OPTS(FRM_WORD(obj, i)), OPTS_HIDE, OPTS_LOCK)) {


### PR DESCRIPTION
(Addresses [Cure Code #1979](http://curecode.org/rebol3/ticket.rsp?id=1979).)

Ensure that duplicate words in `block!` arguments are flagged as temporary, favouring the final value.

The linear search isn't ideal, though it means that existing structures can be re-used without further allocation.
