### PR TITLE
Ensure that binary series constructed from blocks are distinct

### DIFF
--- a/src/core/t-string.c
+++ b/src/core/t-string.c
@@ -231,7 +231,8 @@ static REBSER *make_binary(REBVAL *arg, REBOOL make)
 		break;
 
 	case REB_BLOCK:
-		ser = Join_Binary(arg);
+		// Join_Binary returns a shared buffer, so produce a copy:
+		ser = Copy_Series(Join_Binary(arg));
 		break;
 
 	// MAKE/TO BINARY! <tuple!>


### PR DESCRIPTION
(Addresses [Cure Code #1967](http://curecode.org/rebol3/ticket.rsp?id=1967).)

When passed a block argument, `make_binary` populates and returns a pointer to a temporary buffer in the task context.  As a result, binary series constructed from block specs are subject to unexpected mutation:

```
>> x: to binary! [1]
== #{01}
>> y: to binary! [2]
== #{02}
>> x
== #{02}
>> same? to binary! [1] to binary! [2]
== true
```

Correct this behaviour by returning a copy of the constructed series.
