### PR TITLE
FIND-ALL doc string typo fix

### DIFF
--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -389,7 +389,7 @@ split: func [	; Gabriele, Gregg
 ]
 
 find-all: funct [
-    "Find all occurances of the value within the series (allows modification)."
+    "Find all occurrences of a value within a series (allows modification)."
     'series [word!] "Variable for block, string, or other series"
     value
     body [block!] "Evaluated for each occurance"


### PR DESCRIPTION
The word "occurrences" was misspelled. Also, tweaked to fit in Windows console. See http://issue.cc/r3/2000 for details.
