### PR TITLE
Collect unused GOBs

### DIFF
--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -115,7 +115,11 @@ static void Mark_Series(REBSER *series, REBCNT depth);
 	REBGOB **pane;
 	REBCNT i;
 
-	if (GOB_PANE(gob) && !IS_MARK_SERIES(GOB_PANE(gob))) {
+	if (IS_GOB_MARK(gob)) return;
+
+	MARK_GOB(gob);
+
+	if (GOB_PANE(gob)) {
 		MARK_SERIES(GOB_PANE(gob));
 		pane = GOB_HEAD(gob);
 		for (i = 0; i < GOB_TAIL(gob); i++, pane++) {
@@ -409,6 +413,48 @@ mark_obj:
 
 /***********************************************************************
 **
+*/	static REBCNT Sweep_Gobs(void)
+/*
+**		Free all unmarked gobs.
+**
+**		Scans all gobs in all segments that are part of the
+**		GOB_POOL. Free gobs that have not been marked.
+**
+***********************************************************************/
+{
+	REBSEG	*seg;
+	REBGOB	*gob;
+	REBCNT  n;
+	REBCNT	count = 0;
+
+	for (seg = Mem_Pools[GOB_POOL].segs; seg; seg = seg->next) {
+		gob = (REBGOB *) (seg + 1);
+		for (n = Mem_Pools[GOB_POOL].units; n > 0; n--) {
+#ifdef MUNGWALL
+			gob = (gob *) (((REBYTE *)s)+MUNG_SIZE);
+			MUNG_CHECK(GOB_POOL, gob, sizeof(*gob));
+#endif
+			if (IS_GOB_USED(gob)) {
+				if (IS_GOB_MARK(gob))
+					UNMARK_GOB(gob);
+				else {
+					Free_Gob(gob);
+					count++;
+				}
+			}
+			gob++;
+#ifdef MUNGWALL
+			gob = (gob *) (((REBYTE *)s)+MUNG_SIZE);
+#endif
+		}
+	}
+
+	return count;
+}
+
+
+/***********************************************************************
+**
 */	REBCNT Recycle(void)
 /*
 **		Recycle memory no longer needed.
@@ -475,6 +521,7 @@ mark_obj:
 	Mark_Series(Task_Series, 0);
 
 	count = Sweep_Series();
+	count += Sweep_Gobs();
 
 	CHECK_MEMORY(4);
 

--- a/src/core/m-gc.c
+++ b/src/core/m-gc.c
@@ -115,7 +115,7 @@ static void Mark_Series(REBSER *series, REBCNT depth);
 	REBGOB **pane;
 	REBCNT i;
 
-	if (GOB_PANE(gob)) {
+	if (GOB_PANE(gob) && !IS_MARK_SERIES(GOB_PANE(gob))) {
 		MARK_SERIES(GOB_PANE(gob));
 		pane = GOB_HEAD(gob);
 		for (i = 0; i < GOB_TAIL(gob); i++, pane++) {
@@ -123,7 +123,8 @@ static void Mark_Series(REBSER *series, REBCNT depth);
 		}
 	}
 
-	//if (GOB_PARENT(gob)) Mark_Gob(GOB_PARENT(gob));
+	if (GOB_PARENT(gob)) Mark_Gob(GOB_PARENT(gob), depth);
+
 	if (GOB_CONTENT(gob)) {
 		if (GOB_TYPE(gob) >= GOBT_IMAGE && GOB_TYPE(gob) <= GOBT_STRING) {
 			MARK_SERIES(GOB_CONTENT(gob));

--- a/src/core/m-pools.c
+++ b/src/core/m-pools.c
@@ -538,6 +538,20 @@ clear_header:
 
 /***********************************************************************
 **
+*/	void Free_Gob(REBGOB *gob)
+/*
+**		Free a gob, returning its memory for reuse.
+**
+***********************************************************************/
+{
+	FREE_GOB(gob);
+
+	Free_Node(GOB_POOL, (REBNOD *)gob);
+}
+
+
+/***********************************************************************
+**
 */	void Prop_Series(REBSER *newser, REBSER *oldser)
 /*
 **		Propagate a series from another.

--- a/src/core/t-gob.c
+++ b/src/core/t-gob.c
@@ -68,6 +68,8 @@ const REBCNT Gob_Flag_Words[] = {
 	CLEAR(gob, sizeof(REBGOB));
 	GOB_W(gob) = 100;
 	GOB_H(gob) = 100;
+	USE_GOB(gob);
+	if ((GC_Ballast -= Mem_Pools[GOB_POOL].wide) <= 0) SET_SIGNAL(SIG_RECYCLE);
 	return gob;
 }
 

--- a/src/include/reb-gob.h
+++ b/src/include/reb-gob.h
@@ -174,4 +174,17 @@ struct rebol_gob {		// size: 64 bytes!
 #define IS_GOB_STRING(g) (GOB_CONTENT(g) && GOB_TYPE(g) == GOBT_STRING)
 #define IS_GOB_TEXT(g)   (GOB_CONTENT(g) && GOB_TYPE(g) == GOBT_TEXT)
 
+// GC Flags:
+enum {
+	GOB_MARK = 1,		// Gob was found during GC mark scan.
+	GOB_USED = 1<<1		// Gob is used (not free).
+};
+
+#define IS_GOB_MARK(g)	((g)->resv & GOB_MARK)
+#define MARK_GOB(g)		((g)->resv |= GOB_MARK)
+#define UNMARK_GOB(g)	((g)->resv &= ~GOB_MARK)
+#define IS_GOB_USED(g)	((g)->resv & GOB_USED)
+#define USE_GOB(g)		((g)->resv |= GOB_USED)
+#define FREE_GOB(g)		((g)->resv &= ~GOB_USED)
+
 extern REBGOB *Gob_Root; // Top level GOB (the screen)


### PR DESCRIPTION
Resolving bug#1989.
Define new GOB_MARK and GOB_USED GC flags.
Use the resv field to store GC flags.
