### PR TITLE
do-redirect expects an absolute url so create one

### DIFF
--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -334,6 +334,9 @@ http-response-headers: context [
 do-redirect: func [port [port!] new-uri [url! string! file!] /local spec state] [
 	spec: port/spec
 	state: port/state
+	if #"/" = first new-uri [
+		new-uri: to url! ajoin [spec/scheme "://" spec/host new-uri]
+	]
 	new-uri: construct/with decode-url new-uri port/scheme/spec
 	if new-uri/scheme <> 'http [
 		state/error: make-http-error {Redirect to a protocol different from HTTP not supported}


### PR DESCRIPTION
if do-redirect gets a relative url, it is unable to decode it correctly and so all relative url redirects fail.
