### PR TITLE
Private module imports take precedence

### DIFF
--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -167,16 +167,16 @@ make-module*: func [
 		; All words of the module body are module variables:
 		bind/new body obj
 		; The module keeps its own variables (not shared with system):
+		if object? mixins [resolve obj mixins]
 		;resolve obj sys -- no longer done -Carl
 		resolve obj lib
-		if object? mixins [resolve obj mixins]
 	][
 		; Only top level defined words are module variables.
 		bind/only/set body obj
 		; The module shares system exported variables:
-		if object? mixins [bind body mixins]
 		bind body lib
 		;bind body sys -- no longer done -Carl
+		if object? mixins [bind body mixins]
 	]
 
 	bind body obj


### PR DESCRIPTION
For module Needs imports, give private module exports a
higher priority than runtime library (lib) imports. Doesn't
affect scripts, which use in-order precedence already.

See http://issue.cc/r3/1998 for details.
