### PR TITLE
Fix crash in RESOLVE/extend/only

### DIFF
--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -145,10 +145,14 @@
 	REBSER *words = FRM_WORD_SERIES(frame);
 
 	Extend_Series(frame, delta);
+	BLK_TERM(frame);
 
 	// Expand or copy WORDS block:
 	if (copy) FRM_WORD_SERIES(frame) = Copy_Expand_Block(words, delta);
-	else Extend_Series(words, delta);
+	else {
+		Extend_Series(words, delta);
+		BLK_TERM(words);
+	}
 }
 
 


### PR DESCRIPTION
Ensure that the internal helper function `Expand_Frame` properly terminates the frame's word and value series, even when _not_ copying from the original frame.

The `/extend` handling of `RESOLVE` is currently the only user of non-copying `Expand_Frame`. Without proper termination, the code in `RESOLVE` makes invalid memory accesses at (or past) the frame's tail, causing crashes.

This fixes [CureCode issue #2017](http://issue.cc/r3/2017).
