### PR TITLE
HTTP: remove auto-decoding of UTF-8 content (cc#2027)

### DIFF
--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -28,15 +28,6 @@ sync-op: func [port body /local state] [
 	if state/state = 'ready [do-request port]
 	unless port? wait [state/connection port/spec/timeout] [http-error "Timeout"]
 	body: copy port
-	if all [
-		select state/info/headers 'Content-Type
-		state/info/headers/Content-Type
-		parse state/info/headers/Content-Type [
-			"text/" thru "; charset=UTF-8"
-		]
-	] [
-		body: to string! body
-	]
 	if state/close? [close port]
 	body
 ]


### PR DESCRIPTION
When READing via HTTP (without `/string` or `/lines`), no longer auto-decode UTF-8 encoded content to a `string!`. Always return a `binary!` instead.

The auto-decoding feature removed by this commit lead to brittle code, when developers testing with a site that by chance returned a string! were lead to believe that an http:// READ always returns a `string!`.

This fixes [CureCode issue #2027](http://issue.cc/r3/2027).

Fix as originally suggested by Graham Chiu.
