### PR TITLE
Build Win32 /Core binaries as console mode applications

### DIFF
--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -23,7 +23,7 @@ systems: [
 	[0.1.03 "amiga"      posix  [HID NPS +SC CMT COP -SP -LM]]
 	[0.2.04 "osx"        posix  [+OS NCM -LM]]			; no shared lib possible
 	[0.2.05 "osxi"       posix  [ARC +O1 NPS PIC NCM HID STX -LM]]
-	[0.3.01 "win32"      win32  [+O2 UNI W32 WIN S4M EXE DIR -LM]]
+	[0.3.01 "win32"      win32  [+O2 UNI W32 CON S4M EXE DIR -LM]]
 	[0.4.02 "linux"      posix  [+O2 LDL ST1 -LM]]		; libc 2.3
 	[0.4.03 "linux"      posix  [+O2 HID LDL ST1 -LM]]	; libc 2.5
 	[0.4.04 "linux"      posix  [+O2 HID LDL ST1 M32 -LM]]	; libc 2.11
@@ -60,7 +60,8 @@ linker-flags: [
 	ARC: "-arch i386" ; x86 32 bit architecture (OSX)
 	M32: "-m32"       ; use 32-bit memory model (Linux x64)
 	W32: "-lwsock32 -lcomdlg32"
-	WIN: "-mwindows"; build as Windows GUI binary
+	WIN: "-mwindows" ; build as Windows GUI binary
+	CON: "-mconsole" ; build as Windows Console binary
 	S4M: "-Wl,--stack=4194300"
 	-LM: "-lm" ; HaikuOS has math in libroot, for instance
 	NWK: "-lnetwork" ; Needed by HaikuOS


### PR DESCRIPTION
A console mode Rebol binary has the following advantages:
- Reuses an existing command prompt
- Works with alternative command prompts (such as Console 2)
- Slightly improves the handling of redirected standard IO

Until we reintegrate /View capabilities and/or a custom graphical (R2-style) console, building console mode binaries is the better default for Windows.
