### PR TITLE
FUNCTION and CLOSURE revamp, take 2 (#1973 and #2002)

### DIFF
--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -157,7 +157,7 @@ split-path: func [
 	reduce [dir pos]
 ]
 
-intern: funct [
+intern: function [
 	"Imports (internalize) words and their values from the lib into the user context."
 	data [block! any-word!] "Word or block of words to be added (deeply)"
 ][
@@ -167,7 +167,7 @@ intern: funct [
 	:data
 ]
 
-load: funct [
+load: function [
 	{Simple load of a file, URL, or string/binary - minimal boot version.}
 	source [file! url! string! binary!]
 	/header  {Includes REBOL header object if present}

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -25,7 +25,7 @@ func: make function! [[
 	make function! reduce [spec body]
 ]]
 
-funct: func [
+function: funct: func [
 	{Defines a function with all set-words as locals.}
 	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
 	body [block!] {The body block of the function}

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -11,7 +11,7 @@ REBOL [
 	}
 ]
 
-dt: delta-time: funct [
+dt: delta-time: function [
 	{Delta-time - returns the time it takes to evaluate the block.}
 	block [block!]
 ][
@@ -37,7 +37,7 @@ dp: delta-profile: func [
 	start
 ]
 
-speed?: funct [
+speed?: function [
 	"Returns approximate speed benchmarks [eval cpu memory file-io]."
 	/no-io "Skip the I/O test"
 	/times "Show time for each test"

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -62,7 +62,7 @@ clean-path: func [
 	reverse out
 ]
 
-input: funct [
+input: function [
 	{Inputs a string from the console. New-line character is removed.}
 ;	/hide "Mask input with a * character"
 ][

--- a/src/mezz/mezz-func.r
+++ b/src/mezz/mezz-func.r
@@ -19,15 +19,6 @@ closure: func [
 	make closure! copy/deep reduce [spec body]
 ]
 
-function: func [
-	{Defines a user function with local words.}
-	spec [block!] {Optional help info followed by arg words (and optional type and string)}
-	vars [block!] {List of words that are local to the function}
-	body [block!] {The body block of the function}
-][
-	make function! copy/deep reduce [compose [(spec) /local (vars)] body]
-]
-
 has: func [
 	{A shortcut to define a function that has local variables but no arguments.}
 	vars [block!] {List of words that are local to the function}

--- a/src/mezz/mezz-func.r
+++ b/src/mezz/mezz-func.r
@@ -11,12 +11,42 @@ REBOL [
 	}
 ]
 
-closure: func [
+clos: func [
 	{Defines a closure function.}
 	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
 	body [block!] {The body block of the function}
 ][
 	make closure! copy/deep reduce [spec body]
+]
+
+closure: func [
+	{Defines a closure function with all set-words as locals.}
+	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
+	body [block!] {The body block of the function}
+	/with {Define or use a persistent object (self)}
+	object [object! block! map!] {The object or spec}
+	/extern words [block!] {These words are not local}
+][
+	; Copy the spec and add /local to the end if not found
+	unless find spec: copy/deep spec /local [append spec [
+		/local ; In a block so the generated source gets the newlines
+	]]
+	; Make a full copy of the body, to allow reuse of the original
+	body: copy/deep body
+	; Collect all set-words in the body as words to be used as locals, and add
+	; them to the spec. Don't include the words already in the spec or object.
+	append spec collect-words/deep/set/ignore body either with [
+		; Make our own local object if a premade one is not provided
+		unless object? object [object: make object! object]
+		bind body object  ; Bind any object words found in the body
+		; Ignore the words in the spec and those in the object. The spec needs
+		; to be copied since the object words shouldn't be added to the locals.
+		append append append copy spec 'self words-of object words ; ignore 'self too
+	][
+		; Don't include the words in the spec, or any extern words.
+		either extern [append copy spec words] [spec]
+	]
+	make closure! reduce [spec body]
 ]
 
 has: func [

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -12,7 +12,7 @@ REBOL [
 ]
 
 ; MOVE THIS INTERNAL FUNC:
-dump-obj: funct [
+dump-obj: function [
 	"Returns a block of information about an object or port."
 	obj [object! port!]
 	/match "Include only those that match a string or datatype" pat
@@ -422,7 +422,7 @@ say-browser: does [
 	print "Opening web browser..."
 ]
 
-upgrade: funct [
+upgrade: function [
 	"Check for newer versions (update REBOL)."
 ][
 	print "Fetching upgrade check ..."
@@ -432,7 +432,7 @@ upgrade: funct [
 	exit
 ]
 
-chat: funct [
+chat: function [
 	"Open REBOL DevBase forum/BBS."
 ][
 	print "Fetching chat..."
@@ -489,7 +489,7 @@ why?: func [
 	exit
 ]
 
-demo: funct [
+demo: function [
 	"Run R3 demo."
 ][
 	print "Fetching demo..."
@@ -499,7 +499,7 @@ demo: funct [
 	exit
 ]
 
-load-gui: funct [
+load-gui: function [
 	"Download current GUI module from web. (Temporary)"
 ][
 	print "Fetching GUI..."

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -15,7 +15,7 @@ REBOL [
 	}
 ]
 
-mold64: funct [
+mold64: function [
 	"Temporary function to mold binary base 64." ; fix the need for this! -CS
 	data
 ][
@@ -26,7 +26,7 @@ mold64: funct [
 	data
 ]
 
-save: funct [
+save: function [
 	{Saves a value, block, or other data to a file, URL, binary, or string.}
 	where [file! url! binary! string! none!] {Where to save (suffix determines encoding)}
 	value {Value(s) to save}

--- a/src/mezz/mezz-secure.r
+++ b/src/mezz/mezz-secure.r
@@ -11,7 +11,7 @@ REBOL [
 	}
 ]
 
-secure: funct/with [
+secure: function/with [
 	"Set security policies (use SECURE help for more information)."
 	'policy [word! lit-word! block! unset!] "Set single or multiple policies (or HELP)"
 ] append bind [

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -288,7 +288,7 @@ collect: func [
 	either into [output] [head output]
 ]
 
-format: funct [
+format: function [
 	"Format a string according to the format dialect."
 	rules {A block in the format dialect. E.g. [10 -10 #"-" 4]}
 	values
@@ -429,7 +429,7 @@ split: func [
 	]
 ]
 
-find-all: funct [
+find-all: function [
     "Find all occurrences of a value within a series (allows modification)."
     'series [word!] "Variable for block, string, or other series"
     value

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -203,7 +203,7 @@ export: func [
 	foreach word words [repend lib [word get word]]
 ]
 
-assert-utf8: funct [
+assert-utf8: function [
 	"If binary data is UTF-8, returns it, else throws an error."
 	data [binary!]
 ][

--- a/src/mezz/sys-codec.r
+++ b/src/mezz/sys-codec.r
@@ -17,7 +17,7 @@ REBOL [
 	}
 ]
 
-decode: funct [
+decode: function [
  	{Decodes a series of bytes into the related datatype (e.g. image!).}
 	type [word!] {Media type (jpeg, png, etc.)}
 	data [binary!] {The data to decode}
@@ -31,7 +31,7 @@ decode: funct [
 	data
 ]
 
-encode: funct [
+encode: function [
 	{Encodes a datatype (e.g. image!) into a series of bytes.}
 	type [word!] {Media type (jpeg, png, etc.)}
 	data [image! binary! string!] {The data to encode}
@@ -46,7 +46,7 @@ encode: funct [
 	data
 ]
 
-encoding?: funct [
+encoding?: function [
 	"Returns the media codec name for given binary data. (identify)"
 	data [binary!]
 ][

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -29,7 +29,7 @@ REBOL [
 ; The system/modules list holds modules for fully init'd modules, otherwise it
 ; holds their headers, along with the binary or block that will be used to init them.
 
-intern: funct [
+intern: function [
 	"Imports (internalizes) words/values from the lib into the user context."
 	data [block! any-word!] "Word or block of words to be added (deeply)"
 ][
@@ -73,7 +73,7 @@ mixin?: func [
 	]
 ]
 
-load-header: funct/with [
+load-header: function/with [
 	"Loads script header object and body binary (not loaded)."
 	source [binary! string!] "Source code (string! will be UTF-8 encoded)"
 	/only "Only process header, don't decompress or checksum body"
@@ -165,7 +165,7 @@ load-header: funct/with [
 	non-ws: make bitset! [not 1 - 32]
 ]
 
-load-ext-module: funct [
+load-ext-module: function [
 	"Loads an extension module from an extension object."
 	ext [object!] "Extension object (from LOAD-EXTENSION, modified)"
 	;/local -- don't care if cmd-index and command are defined local
@@ -207,7 +207,7 @@ load-ext-module: funct [
 	reduce [hdr code] ; ready for make module!
 ]
 
-load-boot-exts: funct [
+load-boot-exts: function [
 	"INIT: Load boot-based extensions."
 ][
 	loud-print "Loading boot extensions..."
@@ -246,7 +246,7 @@ load-boot-exts: funct [
 	set 'load-boot-exts 'done ; only once
 ]
 
-read-decode: funct [
+read-decode: function [
 	"Reads code/data from source or DLL, decodes it, returns result (binary, block, image,...)."
 	source [file! url!] "Source or block of sources?"
 	type [word! none!] "File type, or NONE for binary raw data"
@@ -261,7 +261,7 @@ read-decode: funct [
 	data
 ]
 
-load: funct [
+load: function [
 	{Loads code or data from a file, URL, string, or binary.}
 	source [file! url! string! binary! block!] {Source or block of sources}
 	/header  {Result includes REBOL header object (preempts /all)}
@@ -343,7 +343,7 @@ load: funct [
 	:data
 ]
 
-do-needs: funct [
+do-needs: function [
 	"Process the NEEDS block of a program header. Returns unapplied mixins."
 	needs [block! object! tuple! none!] "Needs block, header or version"
 	/no-share "Force module to use its own non-shared global namespace"
@@ -416,7 +416,7 @@ do-needs: funct [
 	]
 ]
 
-load-module: funct [
+load-module: function [
 	{Loads a module (from a file, URL, binary, etc.) and inserts it into the system module list.}
 	source [word! file! url! string! binary! module! block!] {Source or block of sources}
 	/version ver [tuple!] "Module must be this version or greater"
@@ -628,7 +628,7 @@ load-module: funct [
 	reduce [name if module? mod [mod]]
 ]
 
-import: funct [
+import: function [
 	"Imports a module; locate, load, make, and setup its bindings."
 	module [word! file! url! string! binary! module! block!]
 	/version ver [tuple!] "Module must be this version or greater"

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -304,7 +304,7 @@ macro+: func [
 	]
 ]
 
-macro++: funct ['name obj [object!]] [
+macro++: function ['name obj [object!]] [
 	out: make string! 10
 	foreach n words-of obj [
 		all [


### PR DESCRIPTION
This is just pull request #109 updated, to allow for easier merging. No change over #109 as regards content. For convenience, here's the original message of #109:

> The function builder name cleanups as requested in http://issue.cc/r3/1973 and http://issue.cc/r3/2002 make the locals-gathering feature of FUNCT more thoroughly integrated into the language, at least as far as its users are concerned. This will give us the advantages of FUNCT without the limits or the readability issue, and make the name FUNCT optional when we start cleaning down a bit.
