### PR TITLE
Remove SAVE_SERIES/UNSAVE_SERIES around code not calling Recycle.

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -342,7 +342,7 @@ void Trace_Arg(REBINT num, REBVAL *arg, REBVAL *path)
 	VAL_WORD_SYM(tos) = word ? word : SYM__APPLY_;
 	VAL_WORD_INDEX(tos) = -1; // avoid GC access to invalid FRAME above
 	if (func) {
-		VAL_WORD_FRAME(tos) = VAL_FUNC_BODY(func);
+		VAL_WORD_FRAME(tos) = VAL_FUNC_ARGS(func);
 		// Save FUNC value for safety (spec, args, code):
 		tos++;
 		*tos = *func;	// the DSF_FUNC
@@ -1737,7 +1737,7 @@ eval_func2:
 	REBINT n;
 
 	// Caller must: Prep_Func + Args above
-	VAL_WORD_FRAME(DSF_WORD(DSF)) = VAL_FUNC_BODY(func_val);
+	VAL_WORD_FRAME(DSF_WORD(DSF)) = VAL_FUNC_ARGS(func_val);
 	n = DS_ARGC - (SERIES_TAIL(VAL_FUNC_WORDS(func_val)) - 1);
 	for (; n > 0; n--) DS_PUSH_NONE;
 	Func_Dispatch[VAL_TYPE(func_val)-REB_NATIVE](func_val);
@@ -1818,7 +1818,7 @@ push_arg:
 	memmove(DS_ARG(1), DS_TOP-(inew-1), inew * sizeof(REBVAL));
 	DSP = DS_ARG_BASE + inew; // new TOS
 	//Dump_Block(DS_ARG(1), inew);
-	VAL_WORD_FRAME(DSF_WORD(DSF)) = VAL_FUNC_BODY(func_val);
+	VAL_WORD_FRAME(DSF_WORD(DSF)) = VAL_FUNC_ARGS(func_val);
 	*DSF_FUNC(DSF) = *func_val;
 	Func_Dispatch[VAL_TYPE(func_val)-REB_NATIVE](func_val);
 }

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -1000,17 +1000,7 @@
 /*
 ***********************************************************************/
 {
-	REBINT dsf = DSF;
-
-	// Find frame on stack:
-	while (frame != VAL_WORD_FRAME(DSF_WORD(dsf))) {
-		dsf = PRIOR_DSF(dsf);
-		if (dsf <= 0) Trap0(RE_NOT_DEFINED);  // better message !!!!
-	}
-
-	if (IS_FUNCTION(DSF_FUNC(dsf))) {
-		Bind_Relative(VAL_FUNC_ARGS(DSF_FUNC(dsf)), frame, block);
-	}
+	Bind_Relative(frame, frame, block);
 }
 
 
@@ -1020,22 +1010,12 @@
 /*
 ***********************************************************************/
 {
-	REBINT dsf = DSF;
 	REBINT index;
 
-	// Find frame on stack:
-	while (frame != VAL_WORD_FRAME(DSF_WORD(dsf))) {
-	 	dsf = PRIOR_DSF(dsf);
-	 	if (dsf <= 0) Trap1(RE_NOT_IN_CONTEXT, word);
-	}
-
-	if (IS_FUNCTION(DSF_FUNC(dsf))) {
-		index = Find_Arg_Index(VAL_FUNC_ARGS(DSF_FUNC(dsf)), VAL_WORD_SYM(word));
-		if (!index) Trap1(RE_NOT_IN_CONTEXT, word);
-		VAL_WORD_FRAME(word) = frame;
-		VAL_WORD_INDEX(word) = -index;
-	} else
-		Crash(9100); // !!!  function is not there!
+	index = Find_Arg_Index(frame, VAL_WORD_SYM(word));
+	if (!index) Trap1(RE_NOT_IN_CONTEXT, word);
+	VAL_WORD_FRAME(word) = frame;
+	VAL_WORD_INDEX(word) = -index;
 }
 
 

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -449,17 +449,6 @@
 **
 ***********************************************************************/
 {
-	REBVAL *val;
-
-	SAVE_SERIES(dst_frame); // GC - dst_frame has just been created
-
-	// Copy functions:
-	for (val = BLK_SKIP(dst_frame, 1); NOT_END(val); val++) {
-		if (IS_FUNCTION(val) || IS_CLOSURE(val)) Clone_Function(val, val);
-	}
-
-	UNSAVE_SERIES(dst_frame);
-
 	// Rebind all values:
 	Rebind_Block(src_frame, dst_frame, BLK_SKIP(dst_frame, 1), REBIND_FUNC);
 }
@@ -480,7 +469,7 @@
 	PG_Reb_Stats->Objects++;
 
 	if (!block || IS_END(block)) {
-		object = parent ? Clone_Block(parent) : Make_Frame(0);
+		object = parent ? Copy_Block_Values(parent, 0, SERIES_TAIL(parent), TS_CLONE) : Make_Frame(0);
 	} else {
 		words = Collect_Frame(BIND_ONLY, parent, block); // GC safe
 		object = Create_Frame(words, 0); // GC safe
@@ -489,8 +478,7 @@
 				Debug_Fmt(BOOT_STR(RS_WATCH, 2), SERIES_TAIL(parent) - 1, FRM_WORD_SERIES(object));
 			// Copy parent values and deep copy blocks and strings:
 			COPY_VALUES(FRM_VALUES(parent)+1, FRM_VALUES(object)+1, SERIES_TAIL(parent) - 1);
-			Copy_Deep_Values(object, 1, SERIES_TAIL(object), TS_CODE);
-			//Copy_Block_xDeep(object, 1, 0, COPY_OBJECT | COPY_SAME);
+			Copy_Deep_Values(object, 1, SERIES_TAIL(object), TS_CLONE);
 		}
 	}
 

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -455,11 +455,8 @@
 	//DISABLE_GC;
 	// Copy functions:
 	for (val = BLK_SKIP(obj, 1); NOT_END(val); val++) {
-		if (IS_FUNCTION(val)) {
-			Clone_Function(val, val); 
-			funcs = TRUE;
-		}
-		else if (IS_CLOSURE(val)) {
+		if (IS_FUNCTION(val) || IS_CLOSURE(val)) {
+			Clone_Function(val, val);
 			funcs = TRUE;
 		}
 	}
@@ -470,10 +467,8 @@
 	if (funcs) {
 		// Rebind functions:
 		for (val = BLK_SKIP(obj, 1); NOT_END(val); val++) {
-			if (IS_FUNCTION(val)) {
+			if (IS_FUNCTION(val) || IS_CLOSURE(val)) {
 				Bind_Relative(VAL_FUNC_ARGS(val), VAL_FUNC_ARGS(val), VAL_FUNC_BODY(val));
-			}
-			else if (IS_CLOSURE(val)) {
 			}
 		}
 	}
@@ -841,7 +836,7 @@
 		}
 		else if (ANY_BLOCK(value) && (mode & BIND_DEEP))
 			Bind_Block_Words(frame, VAL_BLK_DATA(value), mode);
-		else if (IS_FUNCTION(value) && (mode & BIND_FUNC))
+		else if ((IS_FUNCTION(value) || IS_CLOSURE(value)) && (mode & BIND_FUNC))
 			Bind_Block_Words(frame, BLK_HEAD(VAL_FUNC_BODY(value)), mode);
 	}
 }

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -1021,19 +1021,25 @@
 
 /***********************************************************************
 **
-*/  void Rebind_Block(REBSER *frame_src, REBSER *frame_dst, REBSER *block)
+*/  void Rebind_Block(REBSER *frame_src, REBSER *frame_dst, REBSER *block, REBFLG change_type)
 /*
 **      Rebind all words that reference src frame to dst frame.
 **      Rebind is always deep.
+**
+**		There are two types of frames: relative frames and normal frames.
+**		When frame_src type and frame_dst type differ,
+**		the change_type flag must be TRUE.
 **
 ***********************************************************************/
 {
 	REBVAL *value;
 
 	for (value = BLK_HEAD(block); NOT_END(value); value++) {
-		if (ANY_BLOCK(value)) Rebind_Block(frame_src, frame_dst, VAL_SERIES(value));
+		if (ANY_BLOCK(value)) Rebind_Block(frame_src, frame_dst, VAL_SERIES(value), change_type);
 		else if (ANY_WORD(value) && VAL_WORD_FRAME(value) == frame_src) {
 			VAL_WORD_FRAME(value) = frame_dst;
+			// changing frame type?
+			if (change_type) VAL_WORD_INDEX(value) = - VAL_WORD_INDEX(value);
 		}
 	}
 }

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -260,9 +260,12 @@
 /*
 ***********************************************************************/
 {
+	REBSER *src_frame = VAL_FUNC_ARGS(func);
+
 	VAL_FUNC_SPEC(value) = VAL_FUNC_SPEC(func);
-	VAL_FUNC_ARGS(value) = Copy_Block(VAL_FUNC_ARGS(func), 0);
 	VAL_FUNC_BODY(value) = Clone_Block(VAL_FUNC_BODY(func));
+	VAL_FUNC_ARGS(value) = Copy_Block(src_frame, 0);
+	Rebind_Block(src_frame, VAL_FUNC_ARGS(value), BLK_HEAD(VAL_FUNC_BODY(value)), 0);
 }
 
 
@@ -447,7 +450,7 @@
 	SET_FRAME(BLK_HEAD(frame), 0, VAL_FUNC_ARGS(func));
 
 	// Rebind the body to the new context (deeply):
-	Rebind_Block(VAL_FUNC_ARGS(func), frame, body, TRUE);
+	Rebind_Block(VAL_FUNC_ARGS(func), frame, BLK_HEAD(body), REBIND_TYPE);
 
 	ds = DS_RETURN;
 	SET_OBJECT(ds, body); // keep it GC safe

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -265,6 +265,8 @@
 	VAL_FUNC_SPEC(value) = VAL_FUNC_SPEC(func);
 	VAL_FUNC_BODY(value) = Clone_Block(VAL_FUNC_BODY(func));
 	VAL_FUNC_ARGS(value) = Copy_Block(src_frame, 0);
+	// VAL_FUNC_BODY(value) = Clone_Block(VAL_FUNC_BODY(func));
+	VAL_FUNC_BODY(value) = Copy_Block_Values(VAL_FUNC_BODY(func), 0, SERIES_TAIL(VAL_FUNC_BODY(func)), TS_CLONE);
 	Rebind_Block(src_frame, VAL_FUNC_ARGS(value), BLK_HEAD(VAL_FUNC_BODY(value)), 0);
 }
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -38,64 +38,17 @@
 		word - word, 'word, :word, /word
 		value - typeset! or none (valid datatypes)
 
-	Arg list provides:
+	Args list provides:
 
 		1. specifies arg order, arg kind (e.g. 'word)
 		2. specifies valid datatypes (typesets)
 		3. used for word and type in error output
 		4. used for debugging tools (stack dumps)
 		5. not used for MOLD (spec is used)
-
+		6. used as a (pseudo) frame of function variables
 */
 
 #include "sys-core.h"
-
-#ifdef not_used
-void Dump_Func_Words(REBSER *words)
-{
-	REBINT n;
-
-	for (n = 0; n < (REBINT)SERIES_TAIL(words); n++) {
-		Debug_Fmt("%d: %d", n, WORDS_HEAD(words)[n]);
-	}
-}
-#endif
-
-#ifdef obsolete
-/***********************************************************************
-**
-xx*/	REBSER *Make_Func_Words(REBSER *spec)
-/*
-**		Make a word list part of a context block for a function spec.
-**		This series is stored in the ARGS field of the function value.
-**
-***********************************************************************/
-{
-	REBVAL *word = BLK_HEAD(spec);
-	REBSER *words;
-	REBCNT n;
-	REBCNT len = 0;
-
-	// Count the number of words within the spec:
-	for (n = 0; n < SERIES_TAIL(spec); n++) {
-		if (ANY_WORD(word+n)) len++;
-	}
-
-	// Make the words table:
-	words = Make_Words(len+1);
-
-	// Skip 0th entry (because 0 is not valid for bind index).
-	len = 1;
-	WORDS_HEAD(words)[0] = 0;
-
-	// Initialize the words in the new table.
-	for (n = 0; n < SERIES_TAIL(spec); n++) {
-		if (ANY_WORD(word+n)) WORDS_HEAD(words)[len++] = n;
-	}
-	SERIES_TAIL(words) = len;
-	return words;
-}
-#endif
 
 /***********************************************************************
 **
@@ -232,7 +185,6 @@ xx*/	REBSER *Make_Func_Words(REBSER *spec)
 
 	if (
 		!IS_BLOCK(def)
-////		|| type < REB_CLOSURE // for now
 		|| (len = VAL_LEN(def)) < 2
 		|| !IS_BLOCK(spec = VAL_BLK(def))
 	) return FALSE;
@@ -253,7 +205,7 @@ xx*/	REBSER *Make_Func_Words(REBSER *spec)
 	VAL_SET(value, type);
 
 	if (type == REB_FUNCTION)
-		Bind_Relative(VAL_FUNC_ARGS(value), VAL_FUNC_BODY(value), VAL_FUNC_BODY(value));
+		Bind_Relative(VAL_FUNC_ARGS(value), VAL_FUNC_ARGS(value), VAL_FUNC_BODY(value));
 
 	return TRUE;
 }
@@ -290,7 +242,7 @@ xx*/	REBSER *Make_Func_Words(REBSER *spec)
 
 	// Rebind function words:
 	if (IS_FUNCTION(value))
-		Bind_Relative(VAL_FUNC_ARGS(value), VAL_FUNC_BODY(value), VAL_FUNC_BODY(value));
+		Bind_Relative(VAL_FUNC_ARGS(value), VAL_FUNC_ARGS(value), VAL_FUNC_BODY(value));
 
 	return TRUE;
 }
@@ -303,7 +255,7 @@ xx*/	REBSER *Make_Func_Words(REBSER *spec)
 ***********************************************************************/
 {
 	VAL_FUNC_SPEC(value) = VAL_FUNC_SPEC(func);
-	VAL_FUNC_ARGS(value) = VAL_FUNC_ARGS(func);
+	VAL_FUNC_ARGS(value) = Copy_Block(VAL_FUNC_ARGS(func), 0);
 	VAL_FUNC_BODY(value) = Clone_Block(VAL_FUNC_BODY(func));
 }
 

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -217,17 +217,22 @@
 /*
 ***********************************************************************/
 {
-	REBVAL *spec = VAL_BLK(args);
-	REBVAL *body = VAL_BLK_SKIP(args, 1);
+	REBVAL *spec;
+	REBVAL *body;
 
-	if (IS_END(spec)) body = 0;
-	else {
+	if (!args || ((spec = VAL_BLK(args)) && IS_END(spec))) {
+		body = 0;
+		if (IS_FUNCTION(value)) VAL_FUNC_ARGS(value) = Copy_Block(VAL_FUNC_ARGS(value), 0);
+	} else {
+		body = VAL_BLK_SKIP(args, 1);
 		// Spec given, must be block or *
 		if (IS_BLOCK(spec)) {
 			VAL_FUNC_SPEC(value) = VAL_SERIES(spec);
 			VAL_FUNC_ARGS(value) = Check_Func_Spec(VAL_SERIES(spec));
-		} else
+		} else {
 			if (!IS_STAR(spec)) return FALSE;
+			VAL_FUNC_ARGS(value) = Copy_Block(VAL_FUNC_ARGS(value), 0);
+		}
 	}
 
 	if (body && !IS_END(body)) {
@@ -236,7 +241,7 @@
 		if (!IS_BLOCK(body)) return FALSE;
 		VAL_FUNC_BODY(value) = VAL_SERIES(body);
 	}
-	// No body, use protytpe:
+	// No body, use prototype:
 	else if (IS_FUNCTION(value) || IS_CLOSURE(value))
 		VAL_FUNC_BODY(value) = Clone_Block(VAL_FUNC_BODY(value));
 

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -121,8 +121,6 @@
 {
 	REBVAL *val;
 
-	SAVE_SERIES(block); // GC - may have just been allocated
-
 	for (; index < tail; index++) {
 
 		val = BLK_SKIP(block, index);
@@ -137,10 +135,9 @@
 				if ((types & CP_DEEP) != 0)
 					Copy_Deep_Values(VAL_SERIES(val), 0, VAL_TAIL(val), types);
 			}
-		}
+		} else if (types & TYPESET(VAL_TYPE(val)) & TS_FUNCLOS)
+			Clone_Function(val, val);
 	}
-
-	UNSAVE_SERIES(block);
 }
 
 

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -599,7 +599,6 @@ chk_neg:
 	}
 
 	blk = Make_Block(len*2);
-	SAVE_SERIES(blk);
 
 	str = start;
 	while (NZ(eq = FIND_CHR(str+1, '=')) && NZ(n = LEN_STR(str))) {
@@ -610,7 +609,6 @@ chk_neg:
 
 	Block_As_Map(blk);
 
-	UNSAVE_SERIES(blk);
 	return blk;
 }
 
@@ -661,7 +659,6 @@ chk_neg:
 	}
 
 	blk = Make_Block(len);
-	SAVE_SERIES(blk);
 
 	// First is a dir path or full file path:
 	str = start;
@@ -683,7 +680,6 @@ chk_neg:
 		}
 	}
 
-	UNSAVE_SERIES(blk);
 	return blk;
 }
 #endif

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -81,11 +81,7 @@
 	SET_END(word);
 	SET_END(vals);
 
-	// Keep the frame safe as we copy the body block deeply:
-	SAVE_SERIES(frame);
 	body = Clone_Block_Value(body_blk);
-//	body = Copy_Block_Deep(VAL_SERIES(body_blk), VAL_INDEX(body_blk), 0, COPY_ALL);
-	UNSAVE_SERIES(frame);
 	Bind_Block(frame, BLK_HEAD(body), BIND_DEEP);
 
 	*fram = frame;

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1235,10 +1235,8 @@ STOID Mold_Error(REBVAL *value, REB_MOLD *mold, REBFLG molded)
 		REBSER *blk;
 		Pre_Mold(value, mold);
 		blk = Gob_To_Block(VAL_GOB(value));
-		SAVE_SERIES(blk);
 		Mold_Block_Series(mold, blk, 0, 0);
 		End_Mold(mold);
-		UNSAVE_SERIES(blk);
 	}
 		break;
 

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -335,7 +335,7 @@ static REBSER *Trim_Object(REBSER *obj)
 
 			// make parent none | []
 			if (IS_NONE(arg) || (IS_BLOCK(arg) && IS_EMPTY(arg))) {
-				obj = Clone_Block(src_obj);
+				obj = Copy_Block_Values(src_obj, 0, SERIES_TAIL(src_obj), TS_CLONE);
 				Rebind_Frame(src_obj, obj);
 				break;	// returns obj
 			}

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -253,7 +253,7 @@ static REBSER *Trim_Object(REBSER *obj)
 	REBVAL *arg = D_ARG(2);
 	REBINT n;
 	REBVAL *val;
-	REBSER *obj;
+	REBSER *obj, *src_obj;
 	REBCNT type = 0;
 
 	switch (action) {
@@ -331,19 +331,19 @@ static REBSER *Trim_Object(REBSER *obj)
 		// make parent-object ....
 		if (IS_OBJECT(value)) {
 			type = REB_OBJECT;
-			obj  = VAL_OBJ_FRAME(value);
+			src_obj  = VAL_OBJ_FRAME(value);
 
 			// make parent none | []
 			if (IS_NONE(arg) || (IS_BLOCK(arg) && IS_EMPTY(arg))) {
-				obj = Clone_Block(obj);
-				Bind_Frame(obj);
+				obj = Clone_Block(src_obj);
+				Rebind_Frame(src_obj, obj);
 				break;	// returns obj
 			}
 
 			// make parent [...]
 			if (IS_BLOCK(arg)) {
-				obj = Make_Object(obj, VAL_BLK_DATA(arg));
-				Bind_Frame(obj);
+				obj = Make_Object(src_obj, VAL_BLK_DATA(arg));
+				Rebind_Frame(src_obj, obj);
 				SET_OBJECT(ds, obj);
 				arg = Do_Bind_Block(obj, arg); // GC-OK
 				if (THROWN(arg)) {
@@ -355,7 +355,7 @@ static REBSER *Trim_Object(REBSER *obj)
 
 			// make parent-object object
 			if (IS_OBJECT(arg)) {
-				obj = Merge_Frames(obj, VAL_OBJ_FRAME(arg));
+				obj = Merge_Frames(src_obj, VAL_OBJ_FRAME(arg));
 				break; // returns obj
 			}
 		}

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -160,6 +160,9 @@ enum {
 
 #define TS_CODE ((CP_DEEP | TS_SERIES) & ~TS_NOT_COPIED)
 
+#define TS_FUNCLOS (TYPESET(REB_FUNCTION) | TYPESET(REB_CLOSURE))
+#define TS_CLONE ((CP_DEEP | TS_SERIES | TS_FUNCLOS) & ~TS_NOT_COPIED)
+
 // Modes allowed by Bind related functions:
 enum {
 	BIND_ONLY = 0,		// Only bind the words found in the context.

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -179,6 +179,7 @@ enum {
 enum {
 	REBIND_TYPE = 1,	// Change frame type when rebinding
 	REBIND_FUNC	= 2,	// Rebind function and closure bodies
+	REBIND_TABLE = 4,	// Use bind table when rebinding
 };
 
 // Mold and form options:

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -172,6 +172,12 @@ enum {
 	BIND_NO_SELF = 64,	// Do not bind SELF (in closures)
 };
 
+// Modes for Rebind_Block:
+enum {
+	REBIND_TYPE = 1,	// Change frame type when rebinding
+	REBIND_FUNC	= 2,	// Rebind function and closure bodies
+};
+
 // Mold and form options:
 enum REB_Mold_Opts {
 	MOPT_MOLD_ALL,		// Output lexical types in #[type...] format


### PR DESCRIPTION
Based on #139 (because #139 includes commit 7f691b06 which removes two other unneeded SAVE_SERIES/UNSAVE_SERIES pairs) . Tested in Linux (0.4.4).
