### PR TITLE
Use David M. Gay's STRTOD instead of system specific atof().

### DIFF
--- a/src/core/f-deci.c
+++ b/src/core/f-deci.c
@@ -524,10 +524,11 @@ REBI64 deci_to_int (const deci a) {
 }
 
 REBDEC deci_to_decimal (const deci a) {
-	/* use atof */
+	/* use STRTOD */
+	char *se;
     REBYTE b [34];
 	deci_to_string(b, a, 0, '.');
-	return atof(b);
+	return STRTOD((char *)b, &se);
 }
 
 #define DOUBLE_DIGITS 17

--- a/src/core/l-types.c
+++ b/src/core/l-types.c
@@ -30,6 +30,7 @@
 #include "sys-core.h"
 #include "sys-scan.h"
 #include "sys-deci-funcs.h"
+#include "sys-dec-to-char.h"
 #include <errno.h>
 
 typedef REBFLG (*MAKE_FUNC)(REBVAL *, REBVAL *, REBCNT);
@@ -249,6 +250,7 @@ bad_hex:	Trap0(RE_INVALID_CHARS);
 	REBYTE buf[MAX_NUM_LEN+4];
 	REBYTE *ep = buf;
 	REBOOL dig = FALSE;   /* flag that a digit was present */
+	char *se;
 
 	if (len > MAX_NUM_LEN) return 0;
 
@@ -278,7 +280,7 @@ bad_hex:	Trap0(RE_INVALID_CHARS);
 	if ((REBCNT)(cp-bp) != len) return 0;
 
 	VAL_SET(value, REB_DECIMAL);
-	VAL_DECIMAL(value) = atof((char*)(&buf[0])); // need check for NaN, and INF !!!
+	VAL_DECIMAL(value) = STRTOD((char *)buf, &se); // need check for NaN, and INF !!!
 	if (fabs(VAL_DECIMAL(value)) == HUGE_VAL) Trap0(RE_OVERFLOW);
 	return cp;
 }

--- a/src/include/reb-dtoa.h
+++ b/src/include/reb-dtoa.h
@@ -44,6 +44,7 @@
 
 /* this renames the strtod function to suppress possible conflicts
  * with some overly aggressive definitions in stdlib.h */
+#undef strtod
 #define strtod STRTOD
 
 /* #define IEEE_8087 for IEEE-arithmetic machines where the least

--- a/src/include/reb-dtoa.h
+++ b/src/include/reb-dtoa.h
@@ -1,4 +1,40 @@
-/* This file contains settings for the f-dtoa.c file. */
+/***********************************************************************
+**
+**  REBOL [R3] Language Interpreter and Run-time Environment
+**
+**  REBOL is a trademark of REBOL Technologies
+**
+**  Copyright 2013 Saphirion AG
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**  http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+**
+************************************************************************
+**
+**  Title:  Settings for the f-dtoa.c file
+**  Author: Ladislav Mecir
+**  Notes:
+**
+************************************************************************
+**
+**  NOTE to PROGRAMMERS:
+**
+**    1. Keep code clear and simple.
+**    2. Document unusual code, reasoning, or gotchas.
+**    3. Use same style for code, vars, indent(4), comments, etc.
+**    4. Keep in mind Linux, OS X, BSD, big/little endian CPUs.
+**    5. Test everything, then test it again.
+**
+***********************************************************************/
 
 /* dtoa needs float.h */
 #include <float.h>

--- a/src/include/sys-dec-to-char.h
+++ b/src/include/sys-dec-to-char.h
@@ -2,8 +2,9 @@
 **
 **  REBOL [R3] Language Interpreter and Run-time Environment
 **
-**  Copyright 2012 REBOL Technologies
 **  REBOL is a trademark of REBOL Technologies
+**
+**  Copyright 2012 Saphirion AG
 **
 **  Licensed under the Apache License, Version 2.0 (the "License");
 **  you may not use this file except in compliance with the License.
@@ -19,10 +20,21 @@
 **
 ************************************************************************
 **
-**  Summary: Decimal conversion wrapper
-**  Author:  Carl Sassenrath
+**  Summary: Decimal conversion
+**  Author: Ladislav Mecir
 **  Notes:
+**
+************************************************************************
+**
+**  NOTE to PROGRAMMERS:
+**
+**    1. Keep code clear and simple.
+**    2. Document unusual code, reasoning, or gotchas.
+**    3. Use same style for code, vars, indent(4), comments, etc.
+**    4. Keep in mind Linux, OS X, BSD, big/little endian CPUs.
+**    5. Test everything, then test it again.
 **
 ***********************************************************************/
 
-char * dtoa (double dd, int mode, int ndigits, int *decpt, int *sign, char **rve);
+char *dtoa(double dd, int mode, int ndigits, int *decpt, int *sign, char **rve);
+double STRTOD(const char *s00, char **se);


### PR DESCRIPTION
Improves accuracy and compatibility of LOAD DECIMAL! across platforms.
Improves accuracy and compatibility of MONEY! to DECIMAL! conversions across platforms.
Facilitates interpreter porting.
Battle tested e.g. in Linux, Android, Java, Javascript, Python, Firefox, Chrome.
Tested in Windows (0.3.1) with the following log diff:

```
[equal? to binary! 2.2250738585072007e-308 #{000FFFFFFFFFFFFF}] progression, succeeded
[equal? to binary! 2.2250738585072012e-308 #{0010000000000000}] progression, succeeded

Summary:

new-successes: 0
new-failures: 0
new-crashes: 0
progressions: 2
regressions: 0
removed: 0
unchanged: 4705
total: 4707
```
