### PR TITLE
Modify INTEGER! multiplication to not use division for overflow detection.

### DIFF
--- a/src/include/reb-c.h
+++ b/src/include/reb-c.h
@@ -139,21 +139,20 @@ enum {
 };
 
 
+// Used for MOLDing:
+#define MAX_DIGITS 17   // number of digits
+#define MAX_NUMCHR 32   // space for digits and -.e+000%
+
+#ifdef INT_64_MODE      // Set in reb-config.h
+
 /***********************************************************************
 **
 **  64 Bit Integers - Now supported in REBOL 3.0
 **
 ***********************************************************************/
 
-// Used for MOLDing:
-#define MAX_DIGITS 17   // number of digits
-#define MAX_NUMCHR 32   // space for digits and -.e+000%
-
-#ifdef INT_64_MODE      // Set in config.h
-
 #define MAX_INT_LEN     20
 #define MAX_HEX_LEN     16
-#define MAX_NEG_INT     ((REBI64)(((REBU64)1)<<63))
 
 #ifdef ITOA64           // Integer to ascii conversion
 #define INT_TO_STR(n,s) _i64toa(n, s, 10)
@@ -180,7 +179,6 @@ enum {
 
 #define MAX_INT_LEN     10
 #define MAX_HEX_LEN     8
-#define MAX_NEG_INT     ((REBI64)(((REBU64)1)<<31))
 
 #ifdef ITOA
 #define INT_TO_STR(n,s) itoa(n, s, 10)


### PR DESCRIPTION
Also, the modified multiplication does not use _undefined arithmetic_.
Modify INTEGER! addition and subtraction to not use _undefined arithmetic_ and optimize.
Modify INTEGER! comparison to not use _undefined arithmetic_ - fix [bug#2054](http://issue.cc/r3/2054)
Do not use MAX_NEG_INT (problematic name).
Amend a comment referring to reb-config.h
Tests in Linux (0.4.4) reveal 13 progressions and no regression
Multiplication speed tests reveal improvement
