### PR TITLE
Suppress compiler warnings.

### DIFF
--- a/src/core/f-deci.c
+++ b/src/core/f-deci.c
@@ -536,8 +536,8 @@ REBDEC deci_to_decimal (const deci a) {
 deci decimal_to_deci (REBDEC a) {
 	deci result;
 	REBI64 d; /* decimal significand */
-	REBINT e; /* decimal exponent */
-	REBINT s; /* sign */
+	int e; /* decimal exponent */
+	int s; /* sign */
 	REBYTE *c;
 	REBYTE *rve;
 

--- a/src/core/f-math.c
+++ b/src/core/f-math.c
@@ -392,7 +392,8 @@ static int Convert_Decimal(REBDEC d, REBI64 *sig, REBINT *point)
 
 REBINT Emit_Decimal(REBYTE *cp, REBDEC d, REBFLG trim, REBYTE point, REBINT decimal_digits) {
 	REBYTE *start = cp, *sig, *rve;
-	REBINT e, sgn, digits_obtained;
+	int e, sgn;
+	REBINT digits_obtained;
 
 	/* sanity checks */
 	if (decimal_digits < MIN_DIGITS) decimal_digits = MIN_DIGITS;

--- a/src/core/f-round.c
+++ b/src/core/f-round.c
@@ -86,7 +86,7 @@ enum {
 ***********************************************************************/
 {
 	REBDEC r;
-	REBINT e;
+	int e;
 	REBFLG v;
 	union {REBDEC d; REBI64 i;} m;
 	REBI64 j;

--- a/src/core/u-gif.c
+++ b/src/core/u-gif.c
@@ -294,7 +294,7 @@ void Chrom_Key_Alpha(REBVAL *v,REBCNT col,REBINT blitmode) {
 			Append_Series(VAL_SERIES(Temp2_Value), (REBMEM *)Temp_Value, 1);
 		}
 */
-		dp = codi->bits = Make_Mem(w * h * 4);
+		dp = codi->bits = (u32 *)Make_Mem(w * h * 4);
 		codi->w = w;
 		codi->h = h;
 

--- a/src/core/u-jpg.c
+++ b/src/core/u-jpg.c
@@ -1,6 +1,7 @@
 #define JPEG_INTERNALS
 #define NO_GETENV
-
+#include "reb-config.h"
+#include "reb-c.h"
 #include <setjmp.h>
 #include "sys-jpg.h"
 
@@ -10788,7 +10789,7 @@ extern void Register_Codec(char *name, codo dispatcher);
 
 /***********************************************************************
 **
-*/	int Codec_JPEG_Image(REBCDI *codi)
+*/	REBINT Codec_JPEG_Image(REBCDI *codi)
 /*
 ***********************************************************************/
 {
@@ -10810,7 +10811,7 @@ extern void Register_Codec(char *name, codo dispatcher);
 	if (codi->action == CODI_DECODE) {
 		int w, h;
 		jpeg_info(codi->data, codi->len, &w, &h);
-		codi->bits = (unsigned int *)Make_Mem(w * h * 4);
+		codi->bits = (u32 *)Make_Mem(w * h * 4);
 		jpeg_load(codi->data, codi->len, (char *)codi->bits);
 		codi->w = w;
 		codi->h = h;

--- a/src/include/reb-codec.h
+++ b/src/include/reb-codec.h
@@ -48,13 +48,13 @@ typedef struct reb_codec_image {
 	int alpha;
 	unsigned char *data;
 	union {
-		unsigned int *bits;  // 32 bits
+		u32 *bits;
 		void *other;
 	};
 	int error;
 } REBCDI;
 
-typedef int (*codo)(REBCDI *cdi);
+typedef REBINT (*codo)(REBCDI *cdi);
 
 // Media types:
 enum {

--- a/src/include/reb-config.h
+++ b/src/include/reb-config.h
@@ -69,7 +69,6 @@ These are now obsolete (as of A107) and should be removed:
 
 //* Common *************************************************************
 
-#define INT_64_MODE				// 64 bit integer datatype
 #define THREADED				// enable threads
 
 #ifdef REB_EXE					// standalone exe from RT

--- a/src/include/reb-gob.h
+++ b/src/include/reb-gob.h
@@ -158,9 +158,9 @@ struct rebol_gob {		// size: 64 bytes!
 #define GOB_TAIL(g)		SERIES_TAIL((g)->pane)
 #define GOB_HEAD(g)		((REBGOB **)(SERIES_DATA(GOB_PANE(g))))
 #else
-#define GOB_STRING(g)	((REBYTE *)RL_Series(GOB_CONTENT(g), RXI_SER_DATA))
-#define GOB_TAIL(g)		((REBCNT)RL_Series(GOB_PANE(g), RXI_SER_TAIL))
-#define GOB_HEAD(g)		((REBGOB **)RL_Series(GOB_PANE(g), RXI_SER_DATA))
+#define GOB_STRING(g)	((REBYTE *)RL_Series(GOB_CONTENT(g), (REBCNT)RXI_SER_DATA))
+#define GOB_TAIL(g)		((REBCNT)RL_Series(GOB_PANE(g), (REBCNT)RXI_SER_TAIL))
+#define GOB_HEAD(g)		((REBGOB **)RL_Series(GOB_PANE(g), (REBCNT)RXI_SER_DATA))
 #endif
 #define GOB_BITMAP(g)	GOB_STRING(g)
 #define GOB_SKIP(g,n)	(GOB_HEAD(g)+n)

--- a/src/include/sys-deci-funcs.h
+++ b/src/include/sys-deci-funcs.h
@@ -57,7 +57,7 @@ REBINT deci_to_string(REBYTE *string, const deci a, const REBYTE symbol, const R
 REBYTE *deci_to_binary(REBYTE binary[12], const deci a);
 
 /* math functions */
-deci deci_ldexp (deci a, int e);
+deci deci_ldexp (deci a, REBINT e);
 deci deci_truncate (deci a, deci b);
 deci deci_away (deci a, deci b);
 deci deci_floor (deci a, deci b);


### PR DESCRIPTION
Delete REBDCL type definition (no longer used in code).
Tested in Linux (0.4.4), no regressions
Based on #145 since it updates reb-c.h
