### PR TITLE
Remove int32 from Reb_Val_Data (not used)

### DIFF
--- a/src/include/sys-value.h
+++ b/src/include/sys-value.h
@@ -1091,7 +1091,6 @@ typedef struct Reb_All {
 		REBCNT  logic;
 		REBI64	integer;
 		REBU64	unteger;
-		REBINT	int32;
 		REBDEC	decimal;
 		REBUNI  uchar;
 		REBERR	error;


### PR DESCRIPTION
Tested in Linux (0.4.4) with no regressions.
