### PR TITLE
Fix circular block compare crash, CC#1049

### DIFF
--- a/src/core/f-series.c
+++ b/src/core/f-series.c
@@ -159,6 +159,8 @@ is_true:
 	REBVAL	*t = VAL_BLK_DATA(tval);
 	REBINT	diff;
 
+	CHECK_STACK(&s);
+
 	if ((VAL_SERIES(sval)==VAL_SERIES(tval))&&
 	 (VAL_INDEX(sval)==VAL_INDEX(tval)))
 		 return 0;


### PR DESCRIPTION
Fixes [CC#1049](http://issue.cc/r3/1049)
Tested in Linux (0.4.4) with 3 progressions (successes instead of crashes) and no regression
