### PR TITLE
Fix EVEN? and ODD? to not have undefined behaviour

### DIFF
--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -321,10 +321,8 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 			goto setDec;
 		case A_EVENQ:
 		case A_ODDQ:
-			modf(d1, &d1);
-			num = (REBINT)d1;
-			if (action == A_EVENQ) num = ~num;
-			DECIDE(num & 1);
+			d1 = fabs(fmod(d1, 2.0));
+			DECIDE((action != A_EVENQ) != ((d1 < 0.5) || (d1 >= 1.5)));
 
 		case A_MAKE:
 		case A_TO:


### PR DESCRIPTION
Make EVEN? and ODD? result tolerant to differences from integral values smaller than 0.5
(the greatest tolerance possible in this case)
Tested in Linux (0.4.4) with no regressions.
Tests in Adroid reveal progressions and no regression.

The original version was using an expression which could overflow and thus have _undefined behaviour_. Also, the original version did not tolerate even the smallest differences from integral values, see [CC#1622](http://issue.cc/r3/1622).
