### PR TITLE
Prevent word duplication when appending to an object

### DIFF
--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -265,11 +265,13 @@
 **
 ***********************************************************************/
 {
-	REBVAL *words;
-	REBINT *binds = WORDS_HEAD(Bind_Table); // GC safe to do here
+	REBVAL *words = FRM_WORDS(prior);
+	REBINT *binds = WORDS_HEAD(Bind_Table);
 	REBINT n;
 
-	words = FRM_WORDS(prior);
+	// this is necessary for COPY_VALUES below
+	// to not overwrite memory BUF_WORDS does not own
+	RESIZE_SERIES(BUF_WORDS, SERIES_TAIL(prior));
 	COPY_VALUES(words, BLK_HEAD(BUF_WORDS), SERIES_TAIL(prior));
 	SERIES_TAIL(BUF_WORDS) = SERIES_TAIL(prior);
 	for (n = 1, words++; NOT_END(words); words++) // skips first = SELF

--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -72,15 +72,16 @@ static REBOOL Equal_Object(REBVAL *val, REBVAL *arg)
 
 static void Append_Obj(REBSER *obj, REBVAL *arg)
 {
-	REBCNT i;
-	REBCNT len = 0;
-	REBVAL *val;
-	REBVAL *start = arg;
+	REBCNT i, len;
+	REBVAL *word, *val;
+	REBINT *binds; // for binding table
 
 	// Can be a word:
 	if (ANY_WORD(arg)) {
 		if (!Find_Word_Index(obj, VAL_WORD_SYM(arg), TRUE)) {
-			if (VAL_WORD_CANON(arg) == SYM_SELF) Trap0(RE_SELF_PROTECTED);
+			// bug fix, 'self is protected only in selfish frames
+			if ((VAL_WORD_CANON(arg) == SYM_SELF) && !IS_SELFLESS(obj))
+				Trap0(RE_SELF_PROTECTED);
 			Expand_Frame(obj, 1, 1); // copy word table also
 			Append_Frame(obj, 0, VAL_WORD_SYM(arg));
 			// val is UNSET
@@ -90,48 +91,73 @@ static void Append_Obj(REBSER *obj, REBVAL *arg)
 
 	if (!IS_BLOCK(arg)) Trap_Arg(arg);
 
-	// Verify word/value argument block:
-	for (arg = VAL_BLK_DATA(arg); NOT_END(arg); arg += 2) {
+	// Process word/value argument block:
+	arg = VAL_BLK_DATA(arg);
 
-		if (!IS_WORD(arg) && !IS_SET_WORD(arg)) Trap_Arg(arg);
+	// Use binding table
+	binds = WORDS_HEAD(Bind_Table);
+	// Handle selfless
+	Collect_Start(IS_SELFLESS(obj) ? BIND_NO_SELF | BIND_ALL : BIND_ALL);
+	// Setup binding table with obj words:
+	Collect_Object(obj);
 
-		if (NZ(i = Find_Word_Index(obj, VAL_WORD_SYM(arg), TRUE))) {
-			// Just change the value, do not append it.
-			val = FRM_VALUE(obj, i);
-			if (GET_FLAGS(VAL_OPTS(FRM_WORD(obj, i)), OPTS_HIDE, OPTS_LOCK)) { 
-				// Back out... reset any prior flags:
-				for (; arg != VAL_BLK_DATA(start); arg -= 2) VAL_CLR_OPT(arg, OPTS_TEMP);
-				if (VAL_PROTECTED(FRM_WORD(obj, i))) Trap1(RE_LOCKED_WORD, FRM_WORD(obj, i));
-				Trap0(RE_HIDDEN);
+	// Examine word/value argument block
+	for (word = arg; NOT_END(word); word += 2) {
+
+		if (!IS_WORD(word) && !IS_SET_WORD(word)) {
+			// release binding table
+			BLK_TERM(BUF_WORDS);
+			Collect_End(obj);
+			Trap_Arg(word);
+		}
+
+		if (NZ(i = binds[VAL_WORD_CANON(word)])) {
+			// bug fix, 'self is protected only in selfish frames:
+			if ((VAL_WORD_CANON(word) == SYM_SELF) && !IS_SELFLESS(obj)) {
+				// release binding table
+				BLK_TERM(BUF_WORDS);
+				Collect_End(obj);
+				Trap0(RE_SELF_PROTECTED);
 			}
-			// Problem above: what about prior OPTS_FLAGS? Ok to leave them as is?
-			if (IS_END(arg+1)) SET_NONE(val);
-			else *val = arg[1];
-			VAL_SET_OPT(arg, OPTS_TEMP);
 		} else {
-			if (VAL_WORD_CANON(arg) == SYM_SELF) Trap0(RE_SELF_PROTECTED);
-			len++;
-			// was: Trap1(RE_DUP_VARS, arg);
+			// collect the word
+			binds[VAL_WORD_CANON(word)] = SERIES_TAIL(BUF_WORDS);
+			EXPAND_SERIES_TAIL(BUF_WORDS, 1);
+			val = BLK_LAST(BUF_WORDS);
+			*val = *word;
 		}
-	
-		if (IS_END(arg+1)) break; // fix bug#708
+		if (IS_END(word + 1)) break; // fix bug#708
 	}
 
-	// Append new values to end of frame (if necessary):
-	if (len > 0) {
-		Expand_Frame(obj, len, 1); // copy word table also
-		for (arg = VAL_BLK_DATA(start); NOT_END(arg); arg += 2) {
-			if (VAL_GET_OPT(arg, OPTS_TEMP)) VAL_CLR_OPT(arg, OPTS_TEMP);
-			else {
-				val = Append_Frame(obj, 0, VAL_WORD_SYM(arg));
-				if (IS_END(arg+1)) {
-					SET_NONE(val);
-					break;
-				}
-				else *val = arg[1];
-			}
+	BLK_TERM(BUF_WORDS);
+
+	// Append new words to obj
+	len = SERIES_TAIL(obj);
+	Expand_Frame(obj, SERIES_TAIL(BUF_WORDS) - len, 1);
+	for (word = BLK_SKIP(BUF_WORDS, len); NOT_END(word); word++)
+		Append_Frame(obj, 0, VAL_WORD_SYM(word));
+
+	// Set new values to obj words
+	for (word = arg; NOT_END(word); word += 2) {
+
+		i = binds[VAL_WORD_CANON(word)];
+		val = FRM_VALUE(obj, i);
+		if (GET_FLAGS(VAL_OPTS(FRM_WORD(obj, i)), OPTS_HIDE, OPTS_LOCK)) { 
+			// release binding table
+			Collect_End(obj);
+			if (VAL_PROTECTED(FRM_WORD(obj, i)))
+				Trap1(RE_LOCKED_WORD, FRM_WORD(obj, i));
+			Trap0(RE_HIDDEN);
 		}
+
+		if (IS_END(word + 1)) SET_NONE(val);
+		else *val = word[1];
+
+		if (IS_END(word + 1)) break; // fix bug#708
 	}
+
+	// release binding table
+	Collect_End(obj);
 }
 
 static REBSER *Trim_Object(REBSER *obj)


### PR DESCRIPTION
- Fix [CC#1979](http://issue.cc/r3/1979)
- Amend 'self handling
- Fix [CC#2076](http://issue.cc/r3/2076)
- Optimize the code to not use search

Based on #171 to not cause crashes during the startup of 64-bit R3.

Tested in Linux (0.4.4), no regressions, 4 progressions.
