### PR TITLE
Fixes warnings when building & terminal support under Haiku

### DIFF
--- a/src/include/reb-config.h
+++ b/src/include/reb-config.h
@@ -140,6 +140,7 @@ These are now obsolete (as of A107) and should be removed:
 #define API_EXPORT __attribute__((visibility("default")))
 #else
 #define API_EXPORT
+#define DEF_UINT
 #endif 
 
 #define API_IMPORT

--- a/src/os/posix/host-readline.c
+++ b/src/os/posix/host-readline.c
@@ -429,7 +429,7 @@ static struct termios Term_Attrs;	// Initial settings, restored on exit
 	if (*cp == ESC) {
 		// Escape sequence:
 		cp++;
-		if (*cp == '[') {
+		if (*cp == '[' || *cp == 'O') {
 
 			// Special key:
 			switch (*++cp) {

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -30,7 +30,7 @@ systems: [
 	[0.4.10 "linux_ppc"  posix  [+O1 HID LDL ST1 -LM]]
 	[0.4.20 "linux_arm"  posix  [+O2 HID LDL ST1 -LM]]
 	[0.4.30 "linux_mips" posix  [+O2 HID LDL ST1 -LM]]  ; glibc does not need C++
-	[0.5.75 "haiku"      posix  [+O2 ST1 NWK UIN]]
+	[0.5.75 "haiku"      posix  [+O2 ST1 NWK]]
 	[0.7.02 "freebsd"    posix  [+O1 C++ ST1 -LM]]
 	[0.9.04 "openbsd"    posix  [+O1 C++ ST1 -LM]]
 ]
@@ -50,7 +50,6 @@ compile-flags: [
 	PAK: "-fpack-struct"          ; pack structures
 	ARC: "-arch i386"             ; x86 32 bit architecture (OSX)
 	M32: "-m32"                   ; use 32-bit memory model
-	UIN: "-DDEF_UINT"             ; unsigned int defined
 ]
 
 linker-flags: [

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -30,7 +30,7 @@ systems: [
 	[0.4.10 "linux_ppc"  posix  [+O1 HID LDL ST1 -LM]]
 	[0.4.20 "linux_arm"  posix  [+O2 HID LDL ST1 -LM]]
 	[0.4.30 "linux_mips" posix  [+O2 HID LDL ST1 -LM]]  ; glibc does not need C++
-	[0.5.75 "haiku"      posix  [+O2 ST1 NWK]]
+	[0.5.75 "haiku"      posix  [+O2 ST1 NWK UIN]]
 	[0.7.02 "freebsd"    posix  [+O1 C++ ST1 -LM]]
 	[0.9.04 "openbsd"    posix  [+O1 C++ ST1 -LM]]
 ]
@@ -50,6 +50,7 @@ compile-flags: [
 	PAK: "-fpack-struct"          ; pack structures
 	ARC: "-arch i386"             ; x86 32 bit architecture (OSX)
 	M32: "-m32"                   ; use 32-bit memory model
+	UIN: "-DDEF_UINT"             ; unsigned int defined
 ]
 
 linker-flags: [


### PR DESCRIPTION
Haiku's terminal uses ESC-O instead of ESC-[ as described [here](http://www.freelists.org/post/haiku/Nonstandard-CSI-code,5) in part to strictly comply with xterm. In addition, it defines unsigned ints but doesn't define DEF_UINT in its headers, which caused warning when building. These changes enable additional console functionality and remove the warnings when building.
