### PR TITLE
Free intermediate buffers used by do-codec (CC #2068)

### DIFF
--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -450,14 +450,18 @@ err:
 		memcpy(BIN_HEAD(ser), codi.data, codi.len);
 		Set_Binary(D_RET, ser);
 		if (result != CODI_BINARY) VAL_SET(D_RET, REB_STRING);
-		// Free the binary!
+		
+		// See notice in reb-codec.h on reb_codec_image 
+		Free_Mem(codi.data, codi.len);
 		break;
 
 	case CODI_IMAGE:
 		ser = Make_Image(codi.w, codi.h, TRUE); // Puts it into RETURN stack position
 		memcpy(IMG_DATA(ser), codi.bits, codi.w * codi.h * 4);
 		SET_IMAGE(D_RET, ser);
-		// Free the image!
+
+		// See notice in reb-codec.h on reb_codec_image 
+		Free_Mem(codi.bits, codi.w * codi.h * 4);
 		break;
 
 	case CODI_BLOCK:

--- a/src/include/reb-codec.h
+++ b/src/include/reb-codec.h
@@ -29,6 +29,17 @@
 #define CODI_DEFINED
 
 // Codec image interface:
+//
+// If your codec routine returns CODI_IMAGE, it is expected that the
+// ->bits field contains a block of memory allocated with Make_Mem
+// of size (->w * ->h * 4).  This will be freed by the
+// REBNATIVE(do_codec) in n-system.c
+//
+// If your codec routine returns CODI_BINARY or CODI_TEXT, it is
+// expected that the ->data field contains a block of memory
+// allocated with Make_Mem of size ->len.  This will be freed by
+// the REBNATIVE(do_codec) in n-system.c
+//
 typedef struct reb_codec_image {
 	int action;
 	int w;


### PR DESCRIPTION
Leak from [CC #2068](http://curecode.org/rebol3/ticket.rsp?id=2068).  Found with valgrind but it would have been obvious even without.  Valgrind confirms no leaks afterward.

These two calls to Free_Mem seem to resolve the issue for now.  But it looks like the codec extensibility model is skeletal and ad-hoc at the moment.  See also this question:

http://stackoverflow.com/questions/14365034/how-do-you-write-a-codec-for-rebol-3

A general review of codecs that will work for letting people supply codecs written as Rebol code is needed.  That as well as native JPEG and GIF encoding (as opposed to just decoding)...choosing which codecs to include in minimal builds... among many other considerations.
