### PR TITLE
cc-1748: Guard protected blocks from /INTO target of REDUCE, COMPOSE

### DIFF
--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -267,8 +267,10 @@ x*/	REBSER *Copy_Block_Deep(REBSER *block, REBCNT index, REBINT len, REBCNT mode
 **
 */	void Copy_Stack_Values(REBINT start, REBVAL *into)
 /*
-**		Copy computed values from the stack into a series,
-*		and store it as a block on top of the stack.
+**		Copy computed values from the stack into the series
+**		specified by "into", or if into is NULL then store it as a
+**		block on top of the stack.  (Also checks to see if into
+**		is protected, and will trigger a trap if that is the case.)
 **
 ***********************************************************************/
 {
@@ -280,6 +282,7 @@ x*/	REBSER *Copy_Block_Deep(REBSER *block, REBCNT index, REBINT len, REBCNT mode
 	if (into) {
 		type = VAL_TYPE(into);
 		series = VAL_SERIES(into);
+		if (IS_PROTECT_SERIES(series)) Trap0(RE_PROTECTED);
 		len = Insert_Series(series, VAL_INDEX(into), (REBYTE*)blk, len);
 	} else {
 		series = Make_Series(len + 1, sizeof(REBVAL), FALSE);


### PR DESCRIPTION
[CC #1748](http://curecode.org/rebol3/ticket.rsp?id=1748&cursor=21) pointed out that REDUCE/INTO and COMPOSE/INTO wouldn't check the series passed to /INTO for protection status.  Most of the other checking is done in actions, but these two functions are natives and did not account for the condition.

I added it to the shared code in `Copy_Stack_Values()`.  From a performance standpoint, this means the REDUCE or COMPOSE has already been done by the time the check is run.  But as it's going to throw a trap anyway, the tradeoff of a single check is a good one.

The other functions with /INTO mentioned which did not have the problem (EXTRACT, COLLECT, REWORD) are mezzanines.  Hence they are trusting the core to do the necessary protection checking.
