### PR TITLE
Simplify TO BLOCK! and complex construct via MAKE BLOCK! (CC #2056)

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -238,15 +238,15 @@ reflect: action [
 ;-- Making, copying, modifying
 
 make: action [
-	{Constructs or allocates the specified datatype.}
-	type [any-type!] {The datatype or an example value}
-	spec [any-type!] {Attributes or size of the new value (modified)}
+	{Constructs the given datatype, according to a specification.}
+	type [any-type!] {The target datatype, or example value of the target type}
+	spec [any-type!] {Specification of properties for the new value (modified)}
 ]
 
 to: action [
-	{Converts to a specified datatype.}
-	type [any-type!] {The datatype or example value}
-	spec [any-type!] {The attributes of the new value}
+	{Simple conversion of a value to a given datatype.}
+	type [any-type!] {The target datatype, or example value of the target type}
+	value [any-type!] {The value to convert}
 ]
 
 copy: action [

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -178,6 +178,10 @@ load-ext-module: funct [
 	]
 	;assert/type [hdr object! hdr/options [block! none!] code [binary! block!]]
 
+	; Convert the code to a block if not already.  Should be either block!
+	; or binary!, but may support string! transcoding in the future
+	unless block? code [code: make block! code]
+
 	loud-print ["Extension:" select hdr 'title]
 	unless hdr/options [hdr/options: make block! 1]
 	append hdr/options 'extension ; So make module! special cases it
@@ -201,8 +205,6 @@ load-ext-module: funct [
 		]
 	]
 
-	; Convert the code to a block if not already:
-	unless block? code [code: to block! code]
 	insert code tmp ; Extension object fields and values must be first!
 	reduce [hdr code] ; ready for make module!
 ]
@@ -322,7 +324,7 @@ load: funct [
 		; data is binary or block now, hdr is object or none
 
 		;-- Convert code to block, insert header if requested:
-		not block? data [data: to block! data]
+		not block? data [data: make block! data]
 		header [insert data hdr]
 
 		;-- Bind code to user context:
@@ -607,7 +609,7 @@ load-module: funct [
 						hdr/options: append any [hdr/options make block! 1] 'isolate
 					]
 				]
-				binary? code [code: to block! code]
+				binary? code [code: make block! code]
 			]
 			assert/type [hdr object! code block!]
 			mod: reduce [hdr code do-needs/no-user hdr]


### PR DESCRIPTION
[CC #2056](http://curecode.org/rebol3/ticket.rsp?id=2056) contains a general rallying call to creating a clean philosophy of what TO vs. MAKE were supposed to do.  But that specific ticket has been isolated to deal only with TO BLOCK! and MAKE BLOCK! behavior.

Previously, both TO BLOCK! and MAKE BLOCK! ran through the same function `Make_Block_Type()` with a flag indicating whether the action was A_TO or A_MAKE.  This made the two functions enigmatically similar with unusual exceptions.  This splits the routines into a very simple `To_Block_Type()` which either copies the values of a source block into a new block subtype, or wraps a non-block value inside of a block subtyped type... and then a `Make_Block_Type()` function which does more complicated things with its arguments.

The most immediately-noticeable impact of this change is that TO BLOCK! of a string will wrap the string inside of a block.  This more closely parallels how values like INTEGER! or DATE! were handled before.  To get the tokenization into Rebol values as it used to work, you will have to use MAKE BLOCK!.  This required changes to mezzanine routines for LOAD.

More generally, MAKE BLOCK! no longer falls through to copying blocks if given a block as input.  Instead, a block input to MAKE BLOCK! is reserved for future expansion as a "block allocation dialect".  _(Currently, the only internal creation parameter make supports is an integer specifying a preallocation count for an empty block... e.g. MAKE BLOCK 10.  But if more settings were desired, a block such as `make block! [min-size: 10 max-size: 20]` could be  used to specify the information.)_  If mere duplication of a block is needed, COPY can be used to get the same type or `to output-block-type input-block` if the output block type does not match the input type.

Another difference is that previously TO BLOCK! of a typeset would provide a block containing a list of those types, while MAKE BLOCK! would not do anything with it.  In the spirit of this change, TO BLOCK! will now merely wrap the typeset in a block...while MAKE BLOCK! does the more complex operation.

For clarity, the parameters in the C functions were renamed to better reflect the parameters for the TO and MAKE natives, and the tricky re-use of a REBVAL parameter inside the function was modified to return a REBSER\* (as is done with the corresponding string code.)  In the natives list, this also renames the second parameter of the TO native to "value" in order to differentiate it better from the "spec" taken by MAKE.

This causes two tests in the core-tests suite to fail.  [This one](https://github.com/rebolsource/rebol-test/blob/master/core-tests.r#L82):

```
[[] == to block! ""]
```

and [this one](https://github.com/rebolsource/rebol-test/blob/master/core-tests.r#L1571):

```
; context-less get-word
e: try [do to block! ":a"]
e/id = 'not-defined
```

In both cases, the problem is remedied by changing the TO into a MAKE.
