### PR TITLE
Meanings of TRUE and FALSE w.r.t. INTEGER! for TO vs. MAKE (CC #2055)

### DIFF
--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -143,25 +143,22 @@ static int find_word(REBVAL *val, REBVAL *word)
 
 	case A_MAKE:
 	case A_TO:
-#ifdef removed
-		if (IS_BLOCK(arg)) {
-			REBVAL *val;
-			for (val = VAL_BLK_DATA(arg); NOT_END(val); val++) {
-				if (!IS_WORD(val)) Trap_Arg(val);
-			}
-			VAL_LOGIC(D_RET) = 0;
-			VAL_LOGIC_WORDS(D_RET) = Copy_Block(VAL_SERIES(arg), VAL_INDEX(arg));
-			SET_TYPE(D_RET, REB_LOGIC);
-			return R_RET;
+		{
+			// As a "Rebol conversion", TO falls in line with the rest of the
+			// interpreter canon that all non-none non-logic values are
+			// considered effectively "truth".  As a construction routine,
+			// MAKE takes more liberties in the meaning of its parameters,
+			// so it lets zero values be false.
+
+			REBOOL make = (action == A_MAKE);
+			if (IS_NONE(arg) ||
+				(IS_LOGIC(arg) && !VAL_LOGIC(arg)) ||
+				(IS_INTEGER(arg) && (make && VAL_INT64(arg) == 0)) ||
+				((IS_DECIMAL(arg) || IS_PERCENT(arg)) && (make && VAL_DECIMAL(arg) == 0.0)) ||
+				(IS_MONEY(arg) && (make && deci_is_zero(VAL_DECI(arg))))
+			) goto is_false;
+			goto is_true;
 		}
-#endif
-		if (IS_NONE(arg) ||
-			(IS_LOGIC(arg) && !VAL_LOGIC(arg)) ||
-			(IS_INTEGER(arg) && VAL_INT64(arg) == 0) ||
-			((IS_DECIMAL(arg) || IS_PERCENT(arg)) && VAL_DECIMAL(arg) == 0.0) ||
-			(IS_MONEY(arg) && deci_is_zero(VAL_DECI(arg)))
-		) goto is_false;
-		goto is_true;
 
 #ifdef removed
 	case A_CHANGE:


### PR DESCRIPTION
Very simple change implementing the idea ([CC #2055](http://issue.cc/r3/2055)) that things like TO LOGIC! 0 are TRUE, while things like MAKE LOGIC! 0 remains false.  The converse is that TO INTEGER! TRUE or TO INTEGER! FALSE return errors, while MAKE INTEGER! TRUE returns 1 and MAKE INTEGER! FALSE returns 0.

Does not remove the `true?` or `found?` mezzanines, as consensus on that did not seem to have been reached, and @earl believes that `true? x` can read better than `to logic! x`.  Separate ticket(s) should be opened for those issues.

Three core-tests affected:
- `[false = to logic! 0]` [link](https://github.com/rebolsource/rebol-test/blob/master/core-tests.r#L1793)
- `[0 = to integer! false]` [link](https://github.com/rebolsource/rebol-test/blob/master/core-tests.r#L1692)
- `[1 = to integer! true]` [link](https://github.com/rebolsource/rebol-test/blob/master/core-tests.r#L1693)
