### PR TITLE
Permit SET-WORD! as the argument to COPY and SET in PARSE (CC #2023)

### DIFF
--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -46,7 +46,7 @@ typedef struct reb_parse {
 } REBPARSE;
 
 enum parse_flags {
-	PF_SET,
+	PF_SET_OR_COPY, // test PF_COPY first; if false, this means PF_SET 
 	PF_COPY,
 	PF_NOT,
 	PF_NOT2,
@@ -707,9 +707,9 @@ bad_target:
 					case SYM_COPY:
 						SET_FLAG(flags, PF_COPY);
 					case SYM_SET:
-						SET_FLAG(flags, PF_SET);
+						SET_FLAG(flags, PF_SET_OR_COPY);
 						item = rules++;
-						if (!IS_WORD(item)) Trap1(RE_PARSE_VARIABLE, item);
+						if (!(IS_WORD(item) || IS_SET_WORD(item))) Trap1(RE_PARSE_VARIABLE, item);
 						if (VAL_CMD(item)) Trap1(RE_PARSE_COMMAND, item);
 						word = item;
 						continue;
@@ -788,9 +788,12 @@ bad_target:
 				// Any other cmd must be a match command, so proceed...
 
 			} else { // It's not a PARSE command, get or set it:
-
-				// word: - set a variable to the series at current index
-				if (IS_SET_WORD(item)) {
+			
+				// word: - if not the target of a COPY or SET operation, this will
+				// default to setting a variable to the series at current index
+				if (IS_SET_WORD(item) &&
+					!GET_FLAG(flags, PF_SET_OR_COPY) || GET_FLAG(flags, PF_COPY))
+				{
 					Set_Var_Series(item, parse->type, series, index);
 					continue;
 				}
@@ -991,7 +994,7 @@ post:
 						: Copy_String(series, begin, count); // condenses
 					Set_Var_Series(word, parse->type, ser, 0);
 				}
-				else if (GET_FLAG(flags, PF_SET)) {
+				else if (GET_FLAG(flags, PF_SET_OR_COPY)) {
 					if (IS_BLOCK_INPUT(parse)) {
 						item = Get_Var_Safe(word);
 						if (count == 0) SET_NONE(item);


### PR DESCRIPTION
Implementation of [CC #2023](http://curecode.org/rebol3/ticket.rsp?id=2023&cursor=23)... a seemingly uncontroversial change which allows set-words as arguments to COPY and SET in PARSE.  This is beneficial for the locals-gathering constructs like FUNCTION and CLOSURE.

```
foo: function [] [
    parse "Rebol" [copy name: to end]
]
```

This allows FUNCTION to find `name` and make it /LOCAL instead of leaking into the global context.

The old behavior continues to work as before.
