### PR TITLE
Default splice matching block types else use explicit /SPLICE (CC #2057)

### DIFF
--- a/src/boot/actions.r
+++ b/src/boot/actions.r
@@ -269,23 +269,25 @@ take: action [
 ]
 
 insert: action [
-	{Inserts element(s); for series, returns just past the insert.}
+	{Inserts item, or contents if block type match; returns insert tail.}
 	series [series! port! map! gob! object! bitset! port!] {At position (modified)}
 	value [any-type!] {The value to insert}
 	/part {Limits to a given length or position}
 	length [number! series! pair!]
 	/only {Only insert a block as a single value (not the contents of the block)}
+	/splice {Force splicing semantics even for mismatched any-block! types}
 	/dup {Duplicates the insert a specified number of times}
 	count [number! pair!]
 ]
 
 append: action [
-	{Inserts element(s) at tail; for series, returns head.}
+	{Inserts item at tail, or contents if block type match; returns head.}
 	series [series! port! map! gob! object! bitset!] {Any position (modified)}
 	value [any-type!] {The value to insert}
 	/part {Limits to a given length or position}
 	length [number! series! pair!]
 	/only {Only insert a block as a single value (not the contents of the block)}
+	/splice {Force splicing semantics even for mismatched any-block! types}
 	/dup {Duplicates the insert a specified number of times}
 	count [number! pair!]
 ]
@@ -298,12 +300,13 @@ remove: action [
 ]
 
 change: action [
-	{Replaces element(s); returns just past the change.}
+	{Change to item, or contents if block type match; returns change tail.}
 	series [series! gob! port!]{At position (modified)}
 	value [any-type!] {The new value}
 	/part {Limits the amount to change to a given length or position}
 	length [number! series! pair!]
 	/only {Only change a block as a single value (not the contents of the block)}
+	/splice {Force splicing semantics even for mismatched any-block! types}
 	/dup {Duplicates the change a specified number of times}
 	count [number! pair!]
 ]

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -130,6 +130,7 @@ quote
 do
 into
 only
+splice
 end  ; must be last
 
 ; Event:

--- a/src/core/f-modify.c
+++ b/src/core/f-modify.c
@@ -39,7 +39,7 @@
 **		dst_ser:	target
 **		dst_idx:	position
 **		src_val:    source
-**		flags:		AN_ONLY, AN_PART
+**		flags:		AN_ONLY, AN_SPLICE, AN_PART
 **		dst_len:	length to remove
 **		dups:		dup count
 **
@@ -56,7 +56,8 @@
 	if (action == A_APPEND || dst_idx > tail) dst_idx = tail;
 
 	// Check /PART, compute LEN:
-	if (!GET_FLAG(flags, AN_ONLY) && ANY_BLOCK(src_val)) {
+	if (GET_FLAG(flags, AN_SPLICE)) {
+		ASSERT(ANY_BLOCK(src_val), RP_MISC);
 		is_blk = TRUE; // src_val is a block
 		// Are we modifying ourselves? If so, copy src_val block first:
 		if (dst_ser == VAL_SERIES(src_val)) {

--- a/src/include/sys-core.h
+++ b/src/include/sys-core.h
@@ -160,6 +160,9 @@ enum {
 
 #define TS_CODE ((CP_DEEP | TS_SERIES) & ~TS_NOT_COPIED)
 
+#define TS_FUNCLOS (TYPESET(REB_FUNCTION) | TYPESET(REB_CLOSURE))
+#define TS_CLONE ((CP_DEEP | TS_SERIES | TS_FUNCLOS) & ~TS_NOT_COPIED)
+
 // Modes allowed by Bind related functions:
 enum {
 	BIND_ONLY = 0,		// Only bind the words found in the context.
@@ -170,6 +173,13 @@ enum {
 	BIND_NO_DUP = 16,	// Do not allow dups during word collection (for specs)
 	BIND_FUNC = 32,		// Recurse into functions.
 	BIND_NO_SELF = 64,	// Do not bind SELF (in closures)
+};
+
+// Modes for Rebind_Block:
+enum {
+	REBIND_TYPE = 1,	// Change frame type when rebinding
+	REBIND_FUNC	= 2,	// Rebind function and closure bodies
+	REBIND_TABLE = 4,	// Use bind table when rebinding
 };
 
 // Mold and form options:
@@ -232,6 +242,7 @@ enum Insert_Arg_Nums {
 	AN_PART,
 	AN_LENGTH,
 	AN_ONLY,
+	AN_SPLICE,
 	AN_DUP,
 	AN_COUNT
 };


### PR DESCRIPTION
This implements the nicer invariant that splicing of any-block types for operations such as INSERT, APPEND, and CHANGE only happens if the block types match ([CC #2057](http://issue.cc/r3/2057)).  Otherwise you have to ask for it explicitly:

```
>> append [a b c] [d e f]
== [a b c d e f]

>> append [a b c] 'd/e/f
== [a b c d/e/f]

>> append/splice [a b c] 'd/e/f
== [a b c d e f]
```

For the moment, /splice overrides /only and does not signal an error, if for some reason you use both.  I'd probably prefer an error myself, but @BrianH wants to avoid conflicting-refinement-errors:

```
>> append/only/splice [a b c] 'd/e/f
== [a b c d e f]
```

The PARSE behavior for CHANGE and INSERT required modification as well to support this.  If you have `x: [1 2 "foo" "baz" "bar" 3 4]` then this is how it goes for some various cases:

```
>> parse x [some [to string! change [some string!] [mumble]]] probe x
[1 2 mumble 3 4] ;-- as before

>> parse x [some [to string! change [some string!] only [mumble]]] probe x
[1 2 [mumble] 3 4] ;-- as before

>> parse x [some [to string! change [some string!] (mumble)]] probe x
[1 2 (mumble) 3 4] ;-- new behavior, dropped parens before by default

>> parse x [some [to string! change [some string!] splice (mumble)]] print x
[1 2 mumble 3 4] ;-- new behavior, splice joins only as parse keyword
```

If your x was instead in parens, then this would be different, e.g. with `x: quote (1 2 "foo" "baz" "bar" 3 4)` for these cases:

```
>> parse x [some [to string! change [some string!] (mumble)]] probe x
(1 2 mumble 3 4)

>> parse x [some [to string! change [some string!] [mumble]]] probe x
(1 2 [mumble] 3 4)
```
