### PR TITLE
Fix CATCH/quit interaction with TRY (cc#851)

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -1590,6 +1590,9 @@ eval_func2:
 **
 */	REBOOL Try_Block_Halt(REBSER *block, REBCNT index)
 /*
+**		Evaluate a block from the index position specified in the value,
+**		with a handler for quit conditions (QUIT, HALT) set up.
+**
 ***********************************************************************/
 {
 	REBOL_STATE state;
@@ -1603,12 +1606,10 @@ eval_func2:
 	if (SET_JUMP(state)) {
 //		Debug_Fmt("Throw Halt %d", depth);
 		POP_STATE(state, Halt_State);
-		Saved_State = Halt_State;
 		Catch_Error(DS_NEXT); // Stores error value here
 		return TRUE;
 	}
 	SET_STATE(state, Halt_State);
-	Saved_State = Halt_State;
 
 	SAVE_SERIES(block);
 	val = Do_Blk(block, index);
@@ -1616,7 +1617,6 @@ eval_func2:
 
 	DS_Base[state.dsp+1] = *val;
 	POP_STATE(state, Halt_State);
-	Saved_State = Halt_State;
 
 //	Debug_Fmt("Ret Halt %d", depth);
 
@@ -1653,6 +1653,9 @@ eval_func2:
 		return val;
 	}
 	SET_STATE(state, Halt_State);
+	// Use this handler for both, halt conditions (QUIT, HALT) and error
+	// conditions. As this is a top-level handler, simply overwriting
+	// Saved_State is safe.
 	Saved_State = Halt_State;
 
 	code = Scan_Source(text, LEN_BYTES(text));
@@ -2167,6 +2170,9 @@ xx*/	REBVAL *Do_Path(REBVAL **path_val, REBVAL *val)
 			return -1;
 		}
 		SET_STATE(state, Halt_State);
+		// Use this handler for both, halt conditions (QUIT, HALT) and error
+		// conditions. As this is a top-level handler, simply overwriting
+		// Saved_State is safe.
 		Saved_State = Halt_State;
 
 		val = Do_Sys_Func(SYS_CTX_START, 0); // what if script contains a HALT?

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -368,16 +368,14 @@ enum {
 
 	if (D_REF(4)) {	//QUIT
 		if (Try_Block_Halt(VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)))) {
-			// We can be here for 2 reasons:
-			// 1. a QUIT/HALT condition
-			// 2. an error condition
+			// We are here because of a QUIT/HALT condition.
 			ret = DS_NEXT;
 			if (VAL_ERR_NUM(ret) == RE_QUIT)
 				ret = VAL_ERR_VALUE(ret);
 			else if (VAL_ERR_NUM(ret) == RE_HALT)
 				Halt_Code(RE_HALT, 0);
 			else
-				Throw_Error(VAL_ERR_OBJECT(ret));
+				Crash(RP_NO_CATCH);
 			*DS_RETURN = *ret;
 			return R_RET;
 		}


### PR DESCRIPTION
As reported in [CC#851](http://issue.cc/r3/851), currently, a `catch/quit` incorrectly disables other (outer) error handlers, such as `try` or `attempt`.

The underlying cause is the `catch/quit` implementation incorrectly overwriting the error handler stack. See the commit message for more details on the fix.

This fixes [CureCode issue #851](http://issue.cc/r3/851).
