### PR TITLE
Fix WAIT polling interval on POSIX platforms

### DIFF
--- a/src/os/posix/dev-event.c
+++ b/src/os/posix/dev-event.c
@@ -88,8 +88,9 @@ void Done_Device(int handle, int error);
 **
 */	DEVICE_CMD Query_Events(REBREQ *req)
 /*
-**		Wait for an event or a timeout sepecified by req->length.
-**		This is used by WAIT as the main timing method.
+**		Wait for an event, or a timeout (in milliseconds) specified by
+**		req->length. The latter is used by WAIT as the main timing
+**		method.
 **
 ***********************************************************************/
 {
@@ -97,7 +98,7 @@ void Done_Device(int handle, int error);
 	int result;
 
 	tv.tv_sec = 0;
-	tv.tv_usec = req->length;
+	tv.tv_usec = req->length * 1000;
 	//printf("usec %d\n", tv.tv_usec);
 	
 	result = select(0, 0, 0, 0, &tv);


### PR DESCRIPTION
WAIT with a timeout internally encodes the timeout in milliseconds. The actual POSIX host implementation however inadvertently uses this value as a timeout in microseconds. This leads to a de-facto busy loop when WAITing, as the internal timeouts are simply too short.

Originally discovered by Richard Smolak. Independently reported by Bohdan Lechnowsky.
