### PR TITLE
IF, EITHER, and UNLESS accept all values in then/else slots (CC #2063)

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -131,10 +131,10 @@ do: native [
 ;]
 
 either: native [
-	{If condition is TRUE, evaluates the first block, else evaluates the second.}
+	{If TRUE condition return first arg, else second; evaluate block args.}
 	condition
-	true-block [block!]
-	false-block [block!]
+	true-branch
+	false-branch
 ]
 
 exit: native [
@@ -186,11 +186,11 @@ halt: native [
 ]
 
 if: native [
-	{If condition is TRUE, evaluates the block.}
+	{If TRUE condition, return arg; evaluate block args.}
 	condition
-	then-block [block!]
+	true-branch
 	/else "If not true, evaluate this block"
-	else-block [block!]
+	false-branch
 ]
 
 loop: native [
@@ -306,9 +306,9 @@ try: native [
 ]
 
 unless: native [
-	{Evaluates the block if condition is not TRUE.}
+	{If FALSE condition, return arg; evaluate block args.}
 	condition
-	block [block!]
+	false-branch
 ]
 
 until: native [

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -131,10 +131,11 @@ do: native [
 ;]
 
 either: native [
-	{If TRUE condition return first arg, else second; evaluate block args.}
+	{If TRUE condition return first arg, else second; evaluate blocks by default.}
 	condition
 	true-branch
 	false-branch
+	/only "Suppress evaluation of block args."
 ]
 
 exit: native [
@@ -186,11 +187,12 @@ halt: native [
 ]
 
 if: native [
-	{If TRUE condition, return arg; evaluate block args.}
+	{If TRUE condition, return arg; evaluate block args by default}
 	condition
 	true-branch
-	/else "If not true, evaluate this block"
+	/else "If FALSE condition, return second arg; evaluate block by default"
 	false-branch
+	/only "Suppress evaluation of block args."
 ]
 
 loop: native [
@@ -306,9 +308,10 @@ try: native [
 ]
 
 unless: native [
-	{If FALSE condition, return arg; evaluate block args.}
+	{If FALSE condition, return arg; evaluate block args by default.}
 	condition
 	false-branch
+	/only "Suppress evaluation of block args."
 ]
 
 until: native [

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -355,9 +355,6 @@ xx*/	REBSER *Make_Func_Words(REBSER *spec)
 		case R_ARG3:
 			*ds = *D_ARG(3);
 			break;
-		case R_ARG4:
-			*ds = *D_ARG(4);
-			break;
 		}
 	}
 }
@@ -407,9 +404,6 @@ xx*/	REBSER *Make_Func_Words(REBSER *spec)
 			break;
 		case R_ARG3:
 			*ds = *D_ARG(3);
-			break;
-		case R_ARG4:
-			*ds = *D_ARG(4);
 			break;
 		}
 	}

--- a/src/core/c-function.c
+++ b/src/core/c-function.c
@@ -355,6 +355,9 @@ xx*/	REBSER *Make_Func_Words(REBSER *spec)
 		case R_ARG3:
 			*ds = *D_ARG(3);
 			break;
+		case R_ARG4:
+			*ds = *D_ARG(4);
+			break;
 		}
 	}
 }
@@ -404,6 +407,9 @@ xx*/	REBSER *Make_Func_Words(REBSER *spec)
 			break;
 		case R_ARG3:
 			*ds = *D_ARG(3);
+			break;
+		case R_ARG4:
+			*ds = *D_ARG(4);
 			break;
 		}
 	}

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -642,7 +642,13 @@ got_err:
 		DO_BLK(D_ARG(argnum));
 		return R_TOS1;
 	} {
-		return argnum == 2 ? R_ARG2 : R_ARG4;
+		if (argnum == 2)
+			return R_ARG2;
+		else {
+			// No R_ARG4, but IF/ELSE may get the axe (CC #2077)
+			DS_RET_VALUE(D_ARG(argnum));
+			return R_RET;
+		}
 	}
 
 }

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -593,7 +593,7 @@ got_err:
 {
 	REBCNT argnum = IS_FALSE(D_ARG(1)) ? 3 : 2;
 
-	if (IS_BLOCK(D_ARG(argnum))) {
+	if (IS_BLOCK(D_ARG(argnum)) && !D_REF(4) /* not using /ONLY */) {
 		DO_BLK(D_ARG(argnum));
 		return R_TOS1;
 	} else {
@@ -638,7 +638,7 @@ got_err:
 	} else
 		if (IS_FALSE(cond)) argnum = 4;
 
-	if (IS_BLOCK(D_ARG(argnum))) {
+	if (IS_BLOCK(D_ARG(argnum)) && !D_REF(5) /* not using /ONLY */) {
 		DO_BLK(D_ARG(argnum));
 		return R_TOS1;
 	} {
@@ -790,7 +790,7 @@ got_err:
 ***********************************************************************/
 {
 	if (IS_FALSE(D_ARG(1))) {
-		if (IS_BLOCK(D_ARG(2))) {
+		if (IS_BLOCK(D_ARG(2)) && !D_REF(3) /* not using /ONLY */) {
 			DO_BLK(D_ARG(2));
 			return R_TOS1;
 		} else {

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -591,10 +591,14 @@ got_err:
 /*
 ***********************************************************************/
 {
-	REBVAL *block = IS_FALSE(D_ARG(1)) ? D_ARG(3) : D_ARG(2);
+	REBCNT argnum = IS_FALSE(D_ARG(1)) ? 3 : 2;
 
-	DO_BLK(block);
-	return R_TOS1;
+	if (IS_BLOCK(D_ARG(argnum))) {
+		DO_BLK(D_ARG(argnum));
+		return R_TOS1;
+	} else {
+		return argnum == 2 ? R_ARG2 : R_ARG3;
+	}
 }
 
 
@@ -627,15 +631,20 @@ got_err:
 ***********************************************************************/
 {
 	REBVAL *cond = D_ARG(1);
-	REBVAL *body = D_ARG(2);
+	REBCNT argnum = 2;
 
 	if (!D_REF(3)) {	// no /else
 		if (IS_FALSE(cond)) return R_NONE;
 	} else
-		if (IS_FALSE(cond)) body = D_ARG(4);
+		if (IS_FALSE(cond)) argnum = 4;
 
-	DO_BLK(body);
-	return R_TOS1;
+	if (IS_BLOCK(D_ARG(argnum))) {
+		DO_BLK(D_ARG(argnum));
+		return R_TOS1;
+	} {
+		return argnum == 2 ? R_ARG2 : R_ARG4;
+	}
+
 }
 
 
@@ -775,8 +784,12 @@ got_err:
 ***********************************************************************/
 {
 	if (IS_FALSE(D_ARG(1))) {
-		DO_BLK(D_ARG(2));
-		return R_TOS1;
+		if (IS_BLOCK(D_ARG(2))) {
+			DO_BLK(D_ARG(2));
+			return R_TOS1;
+		} else {
+			return R_ARG2;
+		}
 	}
 	return R_NONE;
 }

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -112,4 +112,5 @@ enum {
 	R_ARG1,
 	R_ARG2,
 	R_ARG3,
+	R_ARG4
 };

--- a/src/include/sys-stack.h
+++ b/src/include/sys-stack.h
@@ -111,6 +111,5 @@ enum {
 	R_FALSE,
 	R_ARG1,
 	R_ARG2,
-	R_ARG3,
-	R_ARG4
+	R_ARG3
 };


### PR DESCRIPTION
Implementation of [CC #2063](http://curecode.org/rebol3/ticket.rsp?id=2063) which makes these natives allow any value in their then/else slots.  Blocks are evaluated as before.

Needed to add R_ARG4, but wouldn't have to in the case that `if/else` were abandoned (which it should be!  no one wants to get Rebol code with `if/else` in it...)
