### PR TITLE
Fix Collect_Object to not overwrite memory BUF_WORDS does not own.

### DIFF
--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -265,11 +265,13 @@
 **
 ***********************************************************************/
 {
-	REBVAL *words;
-	REBINT *binds = WORDS_HEAD(Bind_Table); // GC safe to do here
+	REBVAL *words = FRM_WORDS(prior);
+	REBINT *binds = WORDS_HEAD(Bind_Table);
 	REBINT n;
 
-	words = FRM_WORDS(prior);
+	// this is necessary for COPY_VALUES below
+	// to not overwrite memory BUF_WORDS does not own
+	RESIZE_SERIES(BUF_WORDS, SERIES_TAIL(prior));
 	COPY_VALUES(words, BLK_HEAD(BUF_WORDS), SERIES_TAIL(prior));
 	SERIES_TAIL(BUF_WORDS) = SERIES_TAIL(prior);
 	for (n = 1, words++; NOT_END(words); words++) // skips first = SELF


### PR DESCRIPTION
 Without this fix, Collect_Object was causing crashes in 64-bit R3.
No regressions in Linux (0.4.4)
