### PR TITLE
Amend Init_Frame_Word

### DIFF
--- a/src/core/c-word.c
+++ b/src/core/c-word.c
@@ -323,6 +323,7 @@ make_sym:
 ***********************************************************************/
 {
 	VAL_SET(value, REB_WORD);
+	VAL_SET_OPT(value, OPTS_UNWORD);
 	VAL_BIND_SYM(value) = sym;
 	VAL_BIND_TYPESET(value) = ALL_64;
 }


### PR DESCRIPTION
to set OPTS_UNWORD option to the word added to the frame word list as suggested.
Tested in Linux (0.4.4). No regression.
