### PR TITLE
Add /ONLY refinement to PRINT, deprecate PRIN (CC #2070)

### DIFF
--- a/src/boot/errors.r
+++ b/src/boot/errors.r
@@ -32,6 +32,7 @@ Note: [
 	exited:             [{exit occurred}]
 	deprecated:         {deprecated function not allowed}
 	else-gone:          {ELSE is obsolete - use the EITHER function}
+	prin-gone:			{PRIN is obsolete - use PRINT/ONLY}
 ]
 
 Syntax: [

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -599,13 +599,9 @@ value?: native [
 ;-- IO Natives - nat_io.c
 
 print: native [
-	{Outputs a value followed by a line break.}
+	{Outputs a value to the standard output device.}
 	value [any-type!] {The value to print}
-]
-
-prin: native [
-	{Outputs a value with no line break.}
-	value [any-type!]
+	/only {For a block value, no spaces between components and no newline.}
 ]
 
 mold: native [

--- a/src/core/d-print.c
+++ b/src/core/d-print.c
@@ -393,7 +393,7 @@ static REBREQ *Req_SIO;
 		Debug_Space(1);
 		if (n > 0 && VAL_TYPE(value) <= REB_NONE) Debug_Chars('.', 1);
 		else {
-			out = Mold_Print_Value(value, limit, TRUE); // shared mold buffer
+			out = Mold_Print_Value(value, limit, TRUE, FALSE); // shared mold buffer
 			for (i1 = i2 = 0; i1 < out->tail; i1++) {
 				uc = GET_ANY_CHAR(out, i1);
 				if (uc < ' ') uc = ' ';
@@ -722,7 +722,7 @@ pick:
 			vp = va_arg(args, REBVAL *);
 mold_value:
 			// Form the REBOL value into a reused buffer:
-			ser = Mold_Print_Value(vp, 0, desc != 'v');
+			ser = Mold_Print_Value(vp, 0, desc != 'v', FALSE);
 
 			l = Length_As_UTF8(UNI_HEAD(ser), SERIES_TAIL(ser), TRUE, OS_CRLF);
 			if (pad != 1 && l > pad) l = pad;
@@ -775,14 +775,14 @@ mold_value:
 
 /***********************************************************************
 **
-*/  void Prin_Value(REBVAL *value, REBCNT limit, REBOOL mold)
+*/  void Print_Only_Value(REBVAL *value, REBCNT limit, REBOOL mold)
 /*
 **		Print a value or block's contents for user viewing.
 **		Can limit output to a given size. Set limit to 0 for full size.
 **
 ***********************************************************************/
 {
-	REBSER *out = Mold_Print_Value(value, limit, mold);
+	REBSER *out = Mold_Print_Value(value, limit, mold, TRUE);
 	Prin_OS_String(out->data, out->tail, TRUE);
 }
 
@@ -796,7 +796,8 @@ mold_value:
 **
 ***********************************************************************/
 {
-	Prin_Value(value, limit, mold);
+	REBSER *out = Mold_Print_Value(value, limit, mold, FALSE);
+	Prin_OS_String(out->data, out->tail, TRUE);
 	Print_OS_Line();
 }
 

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -152,9 +152,17 @@ static REBSER *Read_All_File(char *fname)
 ***********************************************************************/
 {
 	REBVAL *value = D_ARG(1);
+	REBOOL splf = !D_REF(2);
 
-	if (IS_BLOCK(value)) Reduce_Block(VAL_SERIES(value), VAL_INDEX(value), 0);
-	Print_Value(DS_TOP, 0, 0);
+	if (IS_BLOCK(value)) {
+		Reduce_Block(VAL_SERIES(value), VAL_INDEX(value), 0);
+		value = DS_TOP;
+	}
+	if (splf) {
+		Print_Value(value, 0, FALSE);
+	} else {
+		Print_Only_Value(value, 0, FALSE);
+	}
 	return R_UNSET; // reloads ds
 }
 
@@ -165,11 +173,8 @@ static REBSER *Read_All_File(char *fname)
 /*
 ***********************************************************************/
 {
-	REBVAL *value = D_ARG(1);
-
-	if (IS_BLOCK(value)) Reduce_Block(VAL_SERIES(value), VAL_INDEX(value), 0);
-	Prin_Value(DS_TOP, 0, 0);
-	return R_UNSET; // reloads ds
+	Trap0(RE_PRIN_GONE);
+	DEAD_END;
 }
 
 

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1382,7 +1382,7 @@ append:
 
 /***********************************************************************
 **
-*/	REBSER *Mold_Print_Value(REBVAL *value, REBCNT limit, REBFLG mold)
+*/	REBSER *Mold_Print_Value(REBVAL *value, REBCNT limit, REBFLG mold, REBFLG tight)
 /*
 **		Basis function for print.  Can do a form or a mold based
 **		on the mold flag setting.  Can limit string output to a
@@ -1393,6 +1393,9 @@ append:
 	REB_MOLD mo = {0};
 
 	Reset_Mold(&mo);
+	if (tight) {
+		SET_FLAG(mo.opts, MOPT_TIGHT);
+	}
 
 	Mold_Value(&mo, value, mold);
 

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -121,3 +121,15 @@ default: func [
 
 secure: func ['d] [boot-print "SECURE is disabled"]
 
+prin: func [
+	{Deprecated print variant that reduces blocks, inserts spaces, no newline}
+	value {Value to print}
+] [
+	if block? value [
+		value: reduce value
+		while [not tail? value: next value] [
+			value: insert value space
+		]
+	]
+	print/only head value
+]

--- a/src/os/host-ext-test.c
+++ b/src/os/host-ext-test.c
@@ -93,7 +93,7 @@ char *RX_Spec =
 			"[cec0 [a: cec1 b: cec1 c: cec1] reduce [a b c]]\n"
 		"][\n"
 			"print [{test:} mold blk]\n"
-			"prin {      } \n"
+			"print/only {      } \n"
 			//"replace {x} {x} {y}\n"
 			"probe do blk\n"
 		"]\n"


### PR DESCRIPTION
This implements [CC #2070](http://curecode.org/rebol3/ticket.rsp?id=2070), and deprecates PRIN to a mezzanine-level function.  Ultimately it should be relocated to R3/Backward.

As the ticket points out, a PRINT variant that omits spaces between block items--in addition to omitting the newline--helps mitigate cases where PRIN might be called several times in succession.
