### PR TITLE
String & binary targets for /INTO in REDUCE+COMPOSE (CC #2081)

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -92,8 +92,8 @@ compose: native [
 	value "Block to compose"
 	/deep "Compose nested blocks"
 	/only {Insert a block as a single value (not the contents of the block)}
-	/into {Output results into a block with no intermediate storage}
-	out [any-block!]
+	/into {Output results into a series with no intermediate storage}
+	out [any-block! any-string! binary!]
 ]
 
 context: native [
@@ -251,8 +251,8 @@ reduce: native [
 	/no-set {Keep set-words as-is. Do not set them.}
 	/only {Only evaluate words and paths, not functions}
 	words [block! none!] {Optional words that are not evaluated (keywords)}
-	/into {Output results into a block with no intermediate storage}
-	out [any-block!]
+	/into {Output results into a series with no intermediate storage}
+	out [any-block! any-string! binary!]
 ]
 
 repeat: native [

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -272,6 +272,10 @@ x*/	REBSER *Copy_Block_Deep(REBSER *block, REBCNT index, REBINT len, REBCNT mode
 **
 ***********************************************************************/
 {
+	// REVIEW: Can we change the interface to not take a REBVAL
+	// for into, in order to better show the subtypes allowed here?
+	// Currently it can be any-block!, any-string!, or binary!
+
 	REBSER *series;
 	REBVAL *blk = DS_Base + start;
 	REBCNT len = DSP - start + 1;
@@ -280,7 +284,43 @@ x*/	REBSER *Copy_Block_Deep(REBSER *block, REBCNT index, REBINT len, REBCNT mode
 	if (into) {
 		type = VAL_TYPE(into);
 		series = VAL_SERIES(into);
-		len = Insert_Series(series, VAL_INDEX(into), (REBYTE*)blk, len);
+		if (ANY_BLOCK(into)) {
+			// When the target is an any-block, we can do an ordinary
+			// insertion of the values via a memcpy()-style operation
+
+			len = Insert_Series(series, VAL_INDEX(into), (REBYTE*)blk, len);
+		} else {
+			// When the target is a string or binary series, we defer
+			// to the same code used by A_INSERT.  Because the interface
+			// does not take a memory address and count, we insert
+			// the values one by one.
+
+			// REVIEW: Is there a way to do this without the loop,
+			// which may be able to make a better guess of how much
+			// to expand the target series by based on the size of
+			// the operation?
+
+			REBCNT i;
+			REBCNT flags = 0;
+			// you get weird behavior if you don't do this
+			if (IS_BINARY(into)) SET_FLAG(flags, AN_SERIES);
+			for (i = 0; i < len; i++) {
+				VAL_INDEX(into) += Modify_String(
+					A_INSERT,
+					VAL_SERIES(into),
+					VAL_INDEX(into) + i,
+					blk + i,
+					flags,
+					1, // insert one element at a time
+					1 // duplication count
+				);
+			}
+
+			// Len is used below to set the index of the result,
+			// and we want it to be just past the last element
+			// that we inserted
+			len = VAL_INDEX(into);
+		}
 	} else {
 		series = Make_Series(len + 1, sizeof(REBVAL), FALSE);
 		COPY_BLK_PART(series, blk, len);


### PR DESCRIPTION
Implementation of [CC #2081](http://curecode.org/rebol3/ticket.rsp?id=2081).

A fully generalized solution might reuse the action dispatcher to work on any SERIES! type.  But this simple change takes care of ANY-STRING! and BINARY! by reusing the Modify_String() function.
