### PR TITLE
[JOIN, REJOIN] mezz => [ADJOIN, JOIN] natives (CC #2079)

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -92,8 +92,8 @@ compose: native [
 	value "Block to compose"
 	/deep "Compose nested blocks"
 	/only {Insert a block as a single value (not the contents of the block)}
-	/into {Output results into a block with no intermediate storage}
-	out [any-block!]
+	/into {Output results into a series with no intermediate storage}
+	out [any-block! any-string! binary!]
 ]
 
 context: native [
@@ -251,8 +251,8 @@ reduce: native [
 	/no-set {Keep set-words as-is. Do not set them.}
 	/only {Only evaluate words and paths, not functions}
 	words [block! none!] {Optional words that are not evaluated (keywords)}
-	/into {Output results into a block with no intermediate storage}
-	out [any-block!]
+	/into {Output results into a series with no intermediate storage}
+	out [any-block! any-string! binary!]
 ]
 
 repeat: native [

--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -18,9 +18,10 @@ REBOL [
 
 ;-- Control Natives - nat_control.c
 
-ajoin: native [
-	{Reduces and joins a block of values into a new string.}
-	block [block!]
+adjoin: native [
+	{Creates a new series concatenating base and rest, with type cued by base.}
+	base {Base value (string converted if scalar, not reduced if block)}
+	rest {Value or block of values (will be reduced if block)}
 ]
 
 also: native [
@@ -191,6 +192,11 @@ if: native [
 	then-block [block!]
 	/else "If not true, evaluate this block"
 	else-block [block!]
+]
+
+join: native [
+	"Reduce a block's first expression, and adjoin it to the remaining content."
+	block [block!] "Values to reduce and join"
 ]
 
 loop: native [

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -302,13 +302,14 @@ x*/	REBSER *Copy_Block_Deep(REBSER *block, REBCNT index, REBINT len, REBCNT mode
 
 			REBCNT i;
 			REBCNT flags = 0;
+			REBCNT offset = VAL_INDEX(into);
 			// you get weird behavior if you don't do this
 			if (IS_BINARY(into)) SET_FLAG(flags, AN_SERIES);
 			for (i = 0; i < len; i++) {
-				VAL_INDEX(into) += Modify_String(
+				offset = Modify_String(
 					A_INSERT,
 					VAL_SERIES(into),
-					VAL_INDEX(into) + i,
+					offset,
 					blk + i,
 					flags,
 					1, // insert one element at a time
@@ -319,7 +320,7 @@ x*/	REBSER *Copy_Block_Deep(REBSER *block, REBCNT index, REBINT len, REBCNT mode
 			// Len is used below to set the index of the result,
 			// and we want it to be just past the last element
 			// that we inserted
-			len = VAL_INDEX(into);
+			len = offset;
 		}
 	} else {
 		series = Make_Series(len + 1, sizeof(REBVAL), FALSE);

--- a/src/core/f-blocks.c
+++ b/src/core/f-blocks.c
@@ -272,6 +272,10 @@ x*/	REBSER *Copy_Block_Deep(REBSER *block, REBCNT index, REBINT len, REBCNT mode
 **
 ***********************************************************************/
 {
+	// REVIEW: Can we change the interface to not take a REBVAL
+	// for into, in order to better show the subtypes allowed here?
+	// Currently it can be any-block!, any-string!, or binary!
+
 	REBSER *series;
 	REBVAL *blk = DS_Base + start;
 	REBCNT len = DSP - start + 1;
@@ -280,7 +284,43 @@ x*/	REBSER *Copy_Block_Deep(REBSER *block, REBCNT index, REBINT len, REBCNT mode
 	if (into) {
 		type = VAL_TYPE(into);
 		series = VAL_SERIES(into);
-		len = Insert_Series(series, VAL_INDEX(into), (REBYTE*)blk, len);
+		if (ANY_BLOCK(into)) {
+			// When the target is an any-block, we can do an ordinary
+			// insertion of the values via a memcpy()-style operation
+
+			len = Insert_Series(series, VAL_INDEX(into), (REBYTE*)blk, len);
+		} else {
+			// When the target is a string or binary series, we defer
+			// to the same code used by A_INSERT.  Because the interface
+			// does not take a memory address and count, we insert
+			// the values one by one.
+
+			// REVIEW: Is there a way to do this without the loop,
+			// which may be able to make a better guess of how much
+			// to expand the target series by based on the size of
+			// the operation?
+
+			REBCNT i;
+			REBCNT flags = 0;
+			// you get weird behavior if you don't do this
+			if (IS_BINARY(into)) SET_FLAG(flags, AN_SERIES);
+			for (i = 0; i < len; i++) {
+				VAL_INDEX(into) += Modify_String(
+					A_INSERT,
+					VAL_SERIES(into),
+					VAL_INDEX(into) + i,
+					blk + i,
+					flags,
+					1, // insert one element at a time
+					1 // duplication count
+				);
+			}
+
+			// Len is used below to set the index of the result,
+			// and we want it to be just past the last element
+			// that we inserted
+			len = VAL_INDEX(into);
+		}
 	} else {
 		series = Make_Series(len + 1, sizeof(REBVAL), FALSE);
 		COPY_BLK_PART(series, blk, len);

--- a/src/mezz/base-debug.r
+++ b/src/mezz/base-debug.r
@@ -34,7 +34,7 @@ probe: func [
 			word? :name
 			path? :name
 		][
-			print ajoin [name ": " mold name: get :name]
+			print join [name ": " mold name: get :name]
 		]
 		block? :name [
 			out: make string! 50

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -29,9 +29,9 @@ title-of:
 
 use [word title] [
 	foreach name system/catalog/reflectors [
-		word: make word! ajoin [name "-of"]
+		word: make word! join [name "-of"]
 		word: bind/new word 'reflect
-		title: ajoin ["Returns a copy of the " name " of a " switch/default name [
+		title: join ["Returns a copy of the " name " of a " switch/default name [
 			spec        ["function or module"]
 			values      ["object or module"]
 			types title ["function"] ; title should include module Title too...

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -16,6 +16,11 @@ REBOL [
 	}
 ]
 
+;; Deprecated - use JOIN which is now functionally equivalent and native.
+;; (or ADJOIN if you specifically wish to join one value with a value or series)
+rejoin: :join 
+
+;; Deprecated - instead of REPEND X Y use APPEND X REDUCE Y
 repend: func [
 	"Appends a reduced value to a series and returns the series head."
 	series [series! port! map! gob! object! bitset!] {Series at point to insert (modified)}
@@ -29,19 +34,32 @@ repend: func [
 	apply :append [series reduce :value part length only dup count]
 ]
 
-join: func [
-	"Concatenates values."
-	value "Base value"
-	rest "Value or block of values"
-][
-	value: either series? :value [copy value] [form :value]
-	repend value :rest
-]
-
+;; Deprecated - instead of REFORM X use FORM REDUCE X
 reform: func [
 	"Forms a reduced block and returns a string."
 	value "Value to reduce and form"
 	;/with "separator"
 ][
 	form reduce :value
+]
+
+;; Deprecated - instead of REMOLD X use MOLD REDUCE X
+remold: func [
+	{Reduces and converts a value to a REBOL-readable string.}
+	value {The value to reduce and mold}
+	/only {For a block value, mold only its contents, no outer []}
+	/all  {Mold in serialized format}
+	/flat {No indentation}
+][
+	apply :mold [reduce :value only all flat]
+]
+
+;; Deprecated - AJOIN X was really just FORM REDUCE X internally
+;; Use ADJOIN {} X or update to be expressed as a JOIN, which
+;; is now faster by virtue of being native.
+ajoin: func [
+	{Reduces and joins a block of values into a new string}
+	block [block!]
+] [
+	adjoin {} block
 ]

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -195,7 +195,7 @@ dump-obj: funct [
 			tmp: http://www.rebol.com/r3/docs/datatypes/
 			remove back tail item ; the !
 		]
-		browse join tmp [item ".html"]
+		browse join [tmp item ".html"]
 	]
 
 	; If arg is a string or datatype! word, search the system:
@@ -227,7 +227,7 @@ dump-obj: funct [
 	type-name: func [value] [
 		value: mold type? :value
 		clear back tail value
-		join either find "aeiou" first value ["an "]["a "] value
+		join [either find "aeiou" first value ["an"] ["a"] space value]
 	]
 
 	; Print literal values:
@@ -269,7 +269,7 @@ dump-obj: funct [
 		print [uppercase mold word args]
 	]
 
-	print ajoin [
+	print join [
 		newline "DESCRIPTION:" newline
 		tab any [title-of :value "(undocumented)"] newline
 		tab uppercase mold word " is " type-name :value " value."
@@ -283,7 +283,7 @@ dump-obj: funct [
 		if empty? list [exit]
 		print label
 		foreach arg list [
-			str: ajoin [tab arg/1]
+			str: join [tab arg/1]
 			if all [extra word? arg/1] [insert str tab]
 			if arg/2 [append append str " -- " arg/2]
 			if all [arg/3 not refinement? arg/1] [
@@ -481,8 +481,9 @@ why?: func [
 		err/type ; avoids lower level error types (like halt)
 	][
 		say-browser
-		err: lowercase ajoin [err/type #"-" err/id]
-		browse join http://www.rebol.com/r3/docs/errors/ [err ".html"]
+		browse lowercase join [
+			http://www.rebol.com/r3/docs/errors/ err/type #"-" err/id %.html
+		]
 	][
 		print "No information is available."
 	]

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -50,27 +50,6 @@ extend: func [
 	:val
 ]
 
-rejoin: func [
-	"Reduces and joins a block of values."
-	block [block!] "Values to reduce and join"
-	;/with "separator"
-][
-	if empty? block: reduce block [return block]
-	append either series? first block [copy first block][
-		form first block
-	] next block
-]
-
-remold: func [
-	{Reduces and converts a value to a REBOL-readable string.}
-	value {The value to reduce and mold}
-	/only {For a block value, mold only its contents, no outer []}
-	/all  {Mold in serialized format}
-	/flat {No indentation}
-][
-	apply :mold [reduce :value only all flat]
-]
-
 charset: func [
 	"Makes a bitset of chars for the parse function."
 	chars [string! block! binary! char! integer!]

--- a/src/mezz/mezz-types.r
+++ b/src/mezz/mezz-types.r
@@ -26,7 +26,7 @@ to-event:
 use [word] [
 	foreach type system/catalog/datatypes [
 		; The list above determines what will be made here:
-		if in lib word: make word! head remove back tail ajoin ["to-" type] [
+		if in lib word: make word! head remove back tail join ["to-" type] [
 			; Add doc line only if this build has autodocs:
 			set in lib :word func either string? first spec-of :make [
 				reduce [reform ["Converts to" form type "value."] 'value]

--- a/src/mezz/prot-http.r
+++ b/src/mezz/prot-http.r
@@ -104,7 +104,7 @@ make-http-error: func [
 	"Make an error for the HTTP protocol"
 	message [string! block!]
 ] [
-	if block? message [message: ajoin message]
+	if block? message [message: join message]
 	make error! [
 		type: 'Access
 		id: 'Protocol
@@ -125,7 +125,7 @@ make-http-request: func [
 	content [any-string! binary! none!] {Request contents (Content-Length is created automatically). Empty string not exactly like none.}
 	/local result
 ] [
-	result: rejoin [
+	result: join [
 		uppercase form method #" "
 		either file? target [next mold target] [target]
 		" HTTP/1.0" CRLF
@@ -153,7 +153,7 @@ do-request: func [
 		Accept: "*/*"
 		Accept-Charset: "utf-8"
 		Host: either spec/port-id <> 80 [
-			rejoin [form spec/host #":" spec/port-id]
+			join [form spec/host #":" spec/port-id]
 		] [
 			form spec/host
 		]
@@ -326,7 +326,7 @@ do-redirect: func [port [port!] new-uri [url! string! file!] /local spec state] 
 	spec: port/spec
 	state: port/state
 	if #"/" = first new-uri [
-		new-uri: to url! ajoin [spec/scheme "://" spec/host new-uri]
+		new-uri: to url! join [to string! spec/scheme "://" spec/host new-uri]
 	]
 	new-uri: construct/with decode-url new-uri port/scheme/spec
 	if new-uri/scheme <> 'http [
@@ -469,7 +469,7 @@ sys/make-scheme [
 				scheme: 'tcp
 				host: port/spec/host
 				port-id: port/spec/port-id
-				ref: rejoin [tcp:// host ":" port-id]
+				ref: join [tcp:// host ":" port-id]
 			]
 			conn/awake: :http-awake
 			conn/locals: port

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -189,7 +189,7 @@ make-module*: func [
 ]
 
 ; MOVE some of these to SYSTEM?
-boot-banner: ajoin ["REBOL 3.0 A" system/version/3 " " system/build newline]
+boot-banner: join ["REBOL 3.0 A" system/version/3 " " system/build newline]
 boot-help: "Boot-sys level - no extra features."
 boot-host: none ; any host add-ons to the lib (binary)
 boot-mezz: none ; built-in mezz code (put here on boot)
@@ -208,7 +208,7 @@ assert-utf8: funct [
 	data [binary!]
 ][
 	unless find [0 8] tmp: utf? data [ ; Not UTF-8
-		cause-error 'script 'no-decode ajoin ["UTF-" abs tmp]
+		cause-error 'script 'no-decode join ["UTF-" abs tmp]
 	]
 	data
 ]

--- a/src/mezz/sys-load.r
+++ b/src/mezz/sys-load.r
@@ -748,6 +748,6 @@ test: [
 		[1 2 3] = probe xload/header %test-emb.r
 	]
 ]
-foreach t test [print either do t ['ok] [join "FAILED:" mold t] print ""]
+foreach t test [print either do t ['ok] [join ["FAILED:" mold t]] print ""]
 halt
 ]

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -26,7 +26,7 @@ make-port*: func [
 	case [
 		file? spec  [
 			name: pick [dir file] dir? spec
-			spec: join [ref:] spec
+			spec: adjoin [ref:] spec
 		]
 		url? spec [
 			spec: repend decode-url spec [to set-word! 'ref spec]

--- a/src/tools/form-header.r
+++ b/src/tools/form-header.r
@@ -12,15 +12,17 @@ REBOL [
 	Author: "Carl Sassenrath"
 ]
 
+do %workarounds.r
+
 bv: load %../boot/version.r
 
 form-header: func [title [string!] file [file!] /gen by] [
 	print ["..." title]
 	by: either gen [
-		rejoin [{**  AUTO-GENERATED FILE - Do not modify. (From: } by {)^/**^/}]
+		join [{**  AUTO-GENERATED FILE - Do not modify. (From: } by {)^/**^/}]
 	][""]
 
-	rejoin [
+	join [
 {/***********************************************************************
 **
 **  REBOL [R3] Language Interpreter and Run-time Environment

--- a/src/tools/make-headers.r
+++ b/src/tools/make-headers.r
@@ -13,6 +13,8 @@ REBOL [
 	Needs: 2.100.100
 ]
 
+do %workarounds.r
+
 print "------ Building headers"
 
 r3: system/version > 2.100.0

--- a/src/tools/make-host-ext.r
+++ b/src/tools/make-host-ext.r
@@ -147,11 +147,11 @@ emit-file: func [
 	emit ["const unsigned char RX_" name "[] = {^/" to-cstr data "^/};^/^/"]
 	emit "#endif^/"
 
-	write rejoin [%../include/ file %.h] out
+	write join [%../include/ file %.h] out
 
 ;	clear out
 ;	emit form-header/gen join title " - Module Initialization" second split-path file %make-host-ext.r
-;	write rejoin [%../os/ file %.c] out
+;	write join [%../os/ file %.c] out
 ]
 
 ;-- Create Files -------------------------------------------------------------

--- a/src/tools/make-host-init.r
+++ b/src/tools/make-host-init.r
@@ -19,6 +19,8 @@ REBOL [
 	}
 ]
 
+do %workarounds.r
+
 print "--- Make Host Init Code ---"
 ;print ["REBOL version:" system/version]
 

--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -300,7 +300,7 @@ macro+: func [
 		thru n any space ["=" | "?="] to newline  ; over simplified
 		insert #" " insert value to end
 	][
-		print ajoin ["Cannot find " name "= definition"]
+		print join ["Cannot find " name "= definition"]
 	]
 ]
 
@@ -354,7 +354,7 @@ emit-file-deps: func [
 ][
 	foreach src files [
 		obj: to-obj src
-		src: rejoin pick [["$R/" src]["$S/" path src]] not dir
+		src: join pick [["$R/" src]["$S/" path src]] not dir
 		emit [
 			%objs/ obj ":" pad obj src
 			newline tab

--- a/src/tools/make-os-ext.r
+++ b/src/tools/make-os-ext.r
@@ -13,6 +13,8 @@ REBOL [
 	Needs: 2.100.100
 ]
 
+do %workarounds.r
+
 verbose: false
 
 version: load %../boot/version.r

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -90,7 +90,7 @@ config-system: func [
 	foreach rec next systems [
 		if rec/1 = v [
 			if os-dir [return dirize to-file rec/3]
-			if define [return to-word uppercase join "TO_" rec/2]
+			if define [return to-word uppercase join ["TO_" rec/2]]
 			return rec
 		]
 	]

--- a/src/tools/workarounds.r
+++ b/src/tools/workarounds.r
@@ -1,0 +1,35 @@
+REBOL [
+	System: "REBOL [R3] Language Interpreter and Run-time Environment"
+	Title: "Workarounds to allow old Rebol builds to bootstrap"
+	Rights: {
+		Copyright 2013 REBOL Technologies
+		REBOL is a trademark of REBOL Technologies
+	}
+	License: {
+		Licensed under the Apache License, Version 2.0.
+		See: http://www.apache.org/licenses/LICENSE-2.0
+	}
+	Purpose: {
+		It is desirable to keep it possible to run the MAKE MAKE and
+		MAKE PREP of Rebol using older interpreters than the latest.
+		This file bridges across possible changes to natives and
+		mezzanines so those steps can keep running despite the 
+		code in the %tools/ and %boot/ directoires being written
+		against the latest assumptions.
+	}
+]
+
+
+;; Newer Rebol interpreters believe JOIN is equivalent to what
+;; older interpreters would have called REJOIN.  We can bridge
+;; past the incompatibility by checking to see if JOIN takes
+;; one or two parameters...and alias it to REJOIN if it takes two
+
+if 2 == length? words-of :join [join: :rejoin]
+
+
+;; Older Rebol interpreters are not aware that the former 3-argument
+;; FUNCTION creator has been deprecated.  Now FUNCTION is the
+;; 2-argument locals gathering mezzanine formerly called FUNCT.
+
+if 3 == length? words-of :function [function: :funct]


### PR DESCRIPTION
This implements [CC #2079](http://curecode.org/rebol3/ticket.rsp?id=2079) by replacing the mezzanines JOIN and REJOIN with natives ADJOIN and JOIN respectively.

Similar to FUNCT => FUNCTION, this is a change where a more popular construction retakes the cleaner name of a less popular construction, that was previously using that name.  (See `%tools/workarounds.r` for how sensing the number of arguments with `words-of` is used to ensure older r3-make binaries can continue to build the bootstrap.  )

For the moment, REJOIN is kept equivalent with JOIN.  The relative unpopularity of the previous JOIN (compared with REJOIN, at least) probably makes it unnecessary to be overly cautious about phasing the change.  Although if one were to be cautious, they could test a codebase to find JOIN instances by unsetting it (same w/FUNCTION).

Performance effects vary, but new JOIN has less overhead.  It's obviously the case that if significant work is happening in the evaluation of the expressions being reduced, the performance gain will become marginal by comparison.

Before:

```
>> delta-time [loop 10000 [rejoin [http://example.com %/number/ {=} "30"]]]
== 0:00:00.022506

>> a: [10 + 20] delta-time [loop 10000 [rejoin [http://example.com %/number/ {=} a]]]
== 0:00:00.025538
```

After:

```
>> delta-time [loop 10000 [join [http://example.com %/number/ {=} "30"]]]
== 0:00:00.009667

>> a: [10 + 20] delta-time [loop 10000 [join [http://example.com %/number/ {=} a]]]  
== 0:00:00.017016
```

Both ADJOIN and JOIN run through the same C function.  But in order to avoid the overhead of doing two REDUCE operations in JOIN, a parameter to the common function had to be added to indicate the `rest` value has already been reduced.  _(Whether this should be exposed as an actual /ONLY refinement is something that can be a consideration.)_

The best feature of this is not the performance, but the edging out of the RExxx conventions for _"REducing variant of XXX"_.  That convention leads to a host of extremely poor names like "REFORM" and "REJOIN"... and if taken to logical conclusions would produce more monsters like "REINSERT" and "RECHANGE".
