### PR TITLE
Add a /only refinement to wait

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -677,6 +677,7 @@ wait: native [
 	{Waits for a duration, port, or both.}
 	value [number! time! port! block! none!]
 	/all {Returns all in a block}
+	/only {only check for ports given in the block to this function}
 ]
 
 wake-up: native [

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -155,7 +155,7 @@
 
 /***********************************************************************
 **
-*/	REBINT Awake_System(REBSER *ports)
+*/	REBINT Awake_System(REBSER *ports, REBINT only)
 /*
 **	Returns:
 **		-1 for errors
@@ -169,6 +169,7 @@
 	REBVAL *waked;
 	REBVAL *awake;
 	REBVAL tmp;
+	REBVAL ref_only;
 	REBVAL *v;
 
 	// Get the system port object:
@@ -194,8 +195,10 @@
 	if (ports) Set_Block(&tmp, ports);
 	else SET_NONE(&tmp);
 
+	if (only) SET_TRUE(&ref_only);
+	else SET_NONE(&ref_only);
 	// Call the system awake function:
-	v = Apply_Func(0, awake, port, &tmp, 0); // ds is return value
+	v = Apply_Func(0, awake, port, &tmp, &ref_only, 0); // ds is return value
 
 	// Awake function returns 1 for end of WAIT:
 	return (IS_LOGIC(v) && VAL_LOGIC(v)) ? 1 : 0;
@@ -204,7 +207,7 @@
 
 /***********************************************************************
 **
-*/	REBINT Wait_Ports(REBSER *ports, REBCNT timeout)
+*/	REBINT Wait_Ports(REBSER *ports, REBCNT timeout, REBINT only)
 /*
 **	Inputs:
 **		Ports: a block of ports or zero (on stack to avoid GC).
@@ -228,7 +231,7 @@
 		}
 
 		// Process any waiting events:
-		if ((result = Awake_System(ports)) > 0) return TRUE;
+		if ((result = Awake_System(ports, only)) > 0) return TRUE;
 
 		// If activity, use low wait time, otherwise increase it:
 		if (result == 0) wt = 1;

--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -371,7 +371,7 @@ chk_neg:
 	if (ports) Set_Block(D_RET, ports);
 
 	// Process port events [stack-move]:
-	if (!Wait_Ports(ports, timeout)) return R_NONE;
+	if (!Wait_Ports(ports, timeout, D_REF(3))) return R_NONE;
 	if (!ports) return R_NONE;
 	DS_RELOAD(ds);
 

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -172,19 +172,33 @@ init-schemes: func [
 		awake: func [
 			sport "System port (State block holds events)"
 			ports "Port list (Copy of block passed to WAIT)"
-			/local event port waked
+			/only
+			/local event event-list n-event port waked
 		][
 			waked: sport/data ; The wake list (pending awakes)
 
+			if only [
+				unless block? ports [return none] ;short cut for a pause
+			]
+
 			; Process all events (even if no awake ports).
 			; Do only 8 events at a time (to prevent polling lockout).
-			loop 8 [
-				unless event: take sport/state [break]
+			n-event: 0
+			event-list: sport/state
+			while [not empty? event-list][
+				if n-event > 8 [break]
+				event: first event-list
 				port: event/port
-				if wake-up port event [
-					; Add port to wake list:
-					;print ["==System-waked:" port/spec/ref]
-					unless find waked port [append waked port]
+				either ((none? only) or (none != find ports port)) [
+					if wake-up port event [
+						; Add port to wake list:
+						;print ["==System-waked:" port/spec/ref]
+						unless find waked port [append waked port]
+					]
+					remove event-list
+					++ n-event
+				][
+					event-list: next event-list
 				]
 			]
 


### PR DESCRIPTION
Such that it only checks events from the ports passed in as the
argument. This could be used to ease sychroneous communication and used
for implementing a pause when the port list is empty (in case of no GUI events).
