### PR TITLE
Fix unwind passing

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -719,6 +719,8 @@ more_path:
 			Trap_Arg(args);
 		}
 
+		if (THROWN(DS_VALUE(ds))) return index;
+
 		// If word is typed, verify correct argument datatype:
 		if (!TYPE_CHECK(args, VAL_TYPE(DS_VALUE(ds))))
 			Trap3(RE_EXPECT_ARG, Func_Word(dsf), args, Of_Type(DS_VALUE(ds)));
@@ -858,8 +860,13 @@ eval_func:
 eval_func2:
 		// Evaluate the function:
 		DSF = dsf;	// Set new DSF
-		if (Trace_Flags) Trace_Func(word, value);
-		Func_Dispatch[ftype](value);
+		if (!THROWN(DS_TOP)) {
+			if (Trace_Flags) Trace_Func(word, value);
+			Func_Dispatch[ftype](value);
+		}
+		else {
+			*DS_RETURN = *DS_TOP;
+		}
 
 		// Reset the stack to prior function frame, but keep the
 		// return value (function result) on the top of the stack.

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -727,7 +727,11 @@ more_path:
 			Trap_Arg(args);
 		}
 
-		if (THROWN(DS_VALUE(ds))) return index;
+		if (THROWN(DS_VALUE(ds))) {
+			// Store THROWN value in TOS, so that Do_Next can handle it.
+			*DS_TOP = *DS_VALUE(ds);
+			return index;
+		}
 
 		// If word is typed, verify correct argument datatype:
 		if (!TYPE_CHECK(args, VAL_TYPE(DS_VALUE(ds))))

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -1314,6 +1314,7 @@ eval_func2:
 		n = 0;
 		while (index < BLK_LEN(block)) {
 			index = Do_Next(block, index, 0);
+			if (THROWN(DS_TOP)) return;
 			n++;
 		}
 		if (n > len) DSP = start + len;

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -1072,6 +1072,7 @@ eval_func2:
 
 	while (index < BLK_LEN(block)) {
 		index = Do_Next(block, index, 0);
+		if (THROWN(DS_TOP)) return;
 	}
 
 	Copy_Stack_Values(start, into);
@@ -1122,6 +1123,8 @@ eval_func2:
 			Do_Path(&v, 0); // pushes val on stack
 		}
 		else DS_PUSH(val);
+		// No need to check for unwinds (THROWN) here, because unwinds should
+		// never be accessible via words or paths.
 	}
 
 	Copy_Stack_Values(start, into);
@@ -1143,6 +1146,7 @@ eval_func2:
 			index++;
 		} else
 			index = Do_Next(block, index, 0);
+		if (THROWN(DS_TOP)) return;
 	}
 
 	Copy_Stack_Values(start, into);

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -661,6 +661,7 @@ x*/	static REBINT Do_Args_Light(REBVAL *func, REBVAL *path, REBSER *block, REBCN
 
 		case REB_WORD:		// WORD - Evaluate next value
 			index = Do_Next(block, index, IS_OP(func));
+			// THROWN is handled after the switch.
 			if (index == END_FLAG) Trap2(RE_NO_ARG, Func_Word(dsf), args);
 			DS_Base[ds] = *DS_POP;
 			break;
@@ -670,6 +671,7 @@ x*/	static REBINT Do_Args_Light(REBVAL *func, REBVAL *path, REBSER *block, REBCN
 				value = BLK_SKIP(block, index);
 				if (IS_PAREN(value) || IS_GET_WORD(value) || IS_GET_PATH(value)) {
 					index = Do_Next(block, index, IS_OP(func));
+					// THROWN is handled after the switch.
 					DS_Base[ds] = *DS_POP;
 				}
 				else {
@@ -845,6 +847,7 @@ reval:
 		word = value;
 		//if (!VAL_WORD_FRAME(word)) Trap1(RE_NOT_DEFINED, word); (checked in set_var)
 		index = Do_Next(block, index+1, 0);
+		// THROWN is handled in Set_Var.
 		if (index == END_FLAG || VAL_TYPE(DS_TOP) <= REB_UNSET) Trap1(RE_NEED_VALUE, word);
 		Set_Var(word, DS_TOP);
 		//Set_Word(word, DS_TOP); // (value stays on stack)
@@ -908,6 +911,7 @@ eval_func2:
 		//Debug_Fmt("t: %r", value);
 		if (ftype == REB_SET_PATH) {
 			index = Do_Next(block, index+1, 0);
+			// THROWN is handled in Do_Path.
 			if (index == END_FLAG || VAL_TYPE(DS_TOP) <= REB_UNSET) Trap1(RE_NEED_VALUE, word);
 			Do_Path(&word, DS_TOP);
 		} else {

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -440,6 +440,12 @@ void Trace_Arg(REBINT num, REBVAL *arg, REBVAL *path)
 {
 	REBPVS pvs;
 
+	if (val && THROWN(val)) {
+		// If unwind/throw value is not coming from TOS, push it.
+		if (val != DS_TOP) DS_PUSH(val);
+		return 0;
+	}
+
 	pvs.setval = val;		// Set to this new value
 	DS_PUSH_NONE;
 	pvs.store = DS_TOP;		// Temp space for constructed results

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -1294,6 +1294,8 @@
 	REBINT dsf;
 	REBSER *frm;
 
+	if (THROWN(value)) return;
+
 	if (!HAS_FRAME(word)) Trap1(RE_NOT_DEFINED, word);
 
 //	ASSERT(index, RP_BAD_SET_INDEX);

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -677,7 +677,7 @@ utop:
 	do {
 		ds = Do_Blk(b1, i1);
 		if (IS_UNSET(ds) || IS_ERROR(ds)) {	// Unset, break, throw, error.
-			if (Check_Error(ds)) return R_TOS1;
+			if (Check_Error(ds) >= 0) return R_TOS1;
 		}
 		if (!IS_TRUE(ds)) return R_RET;
 		ds = Do_Blk(b2, i2);

--- a/src/core/n-strings.c
+++ b/src/core/n-strings.c
@@ -103,6 +103,7 @@ static struct digest {
 	REBSER *str;
 
 	str = Form_Reduce(VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)));
+	if (!str) return R_TOS;
 
 	Set_String(DS_RETURN, str); // not D_RET (stack modified)
 

--- a/src/core/s-mold.c
+++ b/src/core/s-mold.c
@@ -1313,6 +1313,9 @@ append:
 **
 */	REBSER *Form_Reduce(REBSER *block, REBCNT index)
 /*
+**		Reduce a block and then form each value into a string. Return the
+**		string or NULL if an unwind triggered while reducing.
+**
 ***********************************************************************/
 {
 	REBINT start = DSP + 1;
@@ -1321,6 +1324,11 @@ append:
 
 	while (index < BLK_LEN(block)) {
 		index = Do_Next(block, index, 0);
+		if (THROWN(DS_TOP)) {
+			*DS_VALUE(start) = *DS_TOP;
+			DSP = start;
+			return NULL;
+		}
 	}
 
 	Reset_Mold(&mo);


### PR DESCRIPTION
This fixes a whole class of "unwind passing" bugs, which are cases where the "unwind" values that are used to implement the effect of `break` / `continue`, `throw`, `exit` / `return`.

Some simple examples.

```
;; A function that simply "swallows" its argument:
>> K: func [x] []

>> foo: func [] [K return 42 return 99]
>> foo
== 99  ;; The `return 42` is "swallowed" by K. It shouldn't be.
```

Similar bugs are in REDUCE, WHILE, set-word! & set-path! handling, SET, APPLY, and AJOIN. A selection of a few more examples from the related CC tickets:

```
>> error? break
== true
; The unwind is passed to the ERROR? function instead of propagated.
; Should be ** Throw error: no loop to break

>> loop 1 [error? break/return "good" "buggy"]
== "buggy"  ; Should be "good"

>> reduce [return 42]
== [make error! 1]
```

Internally, the problem is that special-case handling for "unwind" values needs to be in place wherever values passing through the interpreter internals. Unwinds should never be assignable or be leaked back to the user level. This series of patches adds the required internal unwind handling.

This fixes CureCode issues [#1509](http://issue.cc/r3/1509), [#1515](http://issue.cc/r3/1515), [#1519](http://issue.cc/r3/1519), [#1760](http://issue.cc/r3/1760).
