### PR TITLE
Update of #164: Have TO LOGIC! 0 return true

### DIFF
--- a/src/core/t-integer.c
+++ b/src/core/t-integer.c
@@ -202,61 +202,58 @@
 
 	case A_MAKE:
 	case A_TO:
-		{
-			REBOOL make = (action == A_MAKE);
-			val = D_ARG(2);
-			if (IS_DECIMAL(val) || IS_PERCENT(val)) {
-				if (VAL_DECIMAL(val) < MIN_D64 || VAL_DECIMAL(val) >= MAX_D64)
-					Trap0(RE_OVERFLOW);
-				num = (REBI64)VAL_DECIMAL(val);
-			}
-			else if (IS_INTEGER(val))
-				num = VAL_INT64(val);
-			else if (IS_MONEY(val))
-				num = deci_to_int(VAL_DECI(val));
-			else if (IS_ISSUE(val)) {
-				REBYTE *bp;
-				REBCNT len;
-				bp = Get_Word_Name(val);
-				len = strlen(bp);
-				n = MIN(MAX_HEX_LEN, len);
-				if (Scan_Hex(bp, &num, n, n) == 0) goto is_bad;
-			}
-			else if (IS_BINARY(val)) { // must be before STRING!
-				REBYTE	*bp;
-				n = VAL_LEN(val);
-				if (n > sizeof(REBI64)) n = sizeof(REBI64);
-				num = 0;
-				for (bp = VAL_BIN_DATA(val); n; n--, bp++)
-					num = (num << 8) | *bp;
-			}
-			else if (ANY_STR(val)) {
-				REBYTE *bp;
-				REBCNT len;
-				bp = Qualify_String(val, MAX_INT_LEN, &len, FALSE);
-				if (memchr(bp, '.', len)) {
-					if (Scan_Decimal(bp, len, DS_RETURN, TRUE)) {
-						num = (REBINT)VAL_DECIMAL(DS_RETURN);
-						break;
-					}
-				}
-				if (Scan_Integer(bp, len, DS_RETURN))
-					return R_RET;
-				goto is_bad;
-			}
-			else if (IS_LOGIC(val)) {
-				// No integer is uniquely representative of true, so TO conversions reject
-				// integer-to-logic conversions.  MAKE is more liberal and constructs true
-				// to 1 and false to 0.
-				if (!make) goto is_bad;
-				num = VAL_LOGIC(val) ? 1 : 0;
-			}
-			else if (IS_CHAR(val))
-				num = VAL_CHAR(val);
-			// else if (IS_NONE(val)) num = 0;
-			else if (IS_TIME (val)) num = SECS_IN(VAL_TIME(val));
-			else goto is_bad;
+		val = D_ARG(2);
+		if (IS_DECIMAL(val) || IS_PERCENT(val)) {
+			if (VAL_DECIMAL(val) < MIN_D64 || VAL_DECIMAL(val) >= MAX_D64)
+				Trap0(RE_OVERFLOW);
+			num = (REBI64)VAL_DECIMAL(val);
 		}
+		else if (IS_INTEGER(val))
+			num = VAL_INT64(val);
+		else if (IS_MONEY(val))
+			num = deci_to_int(VAL_DECI(val));
+		else if (IS_ISSUE(val)) {
+			REBYTE *bp;
+			REBCNT len;
+			bp = Get_Word_Name(val);
+			len = strlen(bp);
+			n = MIN(MAX_HEX_LEN, len);
+			if (Scan_Hex(bp, &num, n, n) == 0) goto is_bad;
+		}
+		else if (IS_BINARY(val)) { // must be before STRING!
+			REBYTE	*bp;
+			n = VAL_LEN(val);
+			if (n > sizeof(REBI64)) n = sizeof(REBI64);
+			num = 0;
+			for (bp = VAL_BIN_DATA(val); n; n--, bp++)
+				num = (num << 8) | *bp;
+		}
+		else if (ANY_STR(val)) {
+			REBYTE *bp;
+			REBCNT len;
+			bp = Qualify_String(val, MAX_INT_LEN, &len, FALSE);
+			if (memchr(bp, '.', len)) {
+				if (Scan_Decimal(bp, len, DS_RETURN, TRUE)) {
+					num = (REBINT)VAL_DECIMAL(DS_RETURN);
+					break;
+				}
+			}
+			if (Scan_Integer(bp, len, DS_RETURN))
+				return R_RET;
+			goto is_bad;
+		}
+		else if (IS_LOGIC(val)) {
+			// No integer is uniquely representative of true, so TO conversions reject
+			// integer-to-logic conversions.  MAKE is more liberal and constructs true
+			// to 1 and false to 0.
+			if (action != A_MAKE) goto is_bad;
+			num = VAL_LOGIC(val) ? 1 : 0;
+		}
+		else if (IS_CHAR(val))
+			num = VAL_CHAR(val);
+		// else if (IS_NONE(val)) num = 0;
+		else if (IS_TIME (val)) num = SECS_IN(VAL_TIME(val));
+		else goto is_bad;
 		break;
 
 	default:

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -143,25 +143,22 @@ static int find_word(REBVAL *val, REBVAL *word)
 
 	case A_MAKE:
 	case A_TO:
-#ifdef removed
-		if (IS_BLOCK(arg)) {
-			REBVAL *val;
-			for (val = VAL_BLK_DATA(arg); NOT_END(val); val++) {
-				if (!IS_WORD(val)) Trap_Arg(val);
-			}
-			VAL_LOGIC(D_RET) = 0;
-			VAL_LOGIC_WORDS(D_RET) = Copy_Block(VAL_SERIES(arg), VAL_INDEX(arg));
-			SET_TYPE(D_RET, REB_LOGIC);
-			return R_RET;
+		{
+			// As a "Rebol conversion", TO falls in line with the rest of the
+			// interpreter canon that all non-none non-logic values are
+			// considered effectively "truth".  As a construction routine,
+			// MAKE takes more liberties in the meaning of its parameters,
+			// so it lets zero values be false.
+
+			REBOOL make = (action == A_MAKE);
+			if (IS_NONE(arg) ||
+				(IS_LOGIC(arg) && !VAL_LOGIC(arg)) ||
+				(IS_INTEGER(arg) && (make && VAL_INT64(arg) == 0)) ||
+				((IS_DECIMAL(arg) || IS_PERCENT(arg)) && (make && VAL_DECIMAL(arg) == 0.0)) ||
+				(IS_MONEY(arg) && (make && deci_is_zero(VAL_DECI(arg))))
+			) goto is_false;
+			goto is_true;
 		}
-#endif
-		if (IS_NONE(arg) ||
-			(IS_LOGIC(arg) && !VAL_LOGIC(arg)) ||
-			(IS_INTEGER(arg) && VAL_INT64(arg) == 0) ||
-			((IS_DECIMAL(arg) || IS_PERCENT(arg)) && VAL_DECIMAL(arg) == 0.0) ||
-			(IS_MONEY(arg) && deci_is_zero(VAL_DECI(arg)))
-		) goto is_false;
-		goto is_true;
 
 #ifdef removed
 	case A_CHANGE:

--- a/src/core/t-logic.c
+++ b/src/core/t-logic.c
@@ -143,22 +143,18 @@ static int find_word(REBVAL *val, REBVAL *word)
 
 	case A_MAKE:
 	case A_TO:
-		{
-			// As a "Rebol conversion", TO falls in line with the rest of the
-			// interpreter canon that all non-none non-logic values are
-			// considered effectively "truth".  As a construction routine,
-			// MAKE takes more liberties in the meaning of its parameters,
-			// so it lets zero values be false.
-
-			REBOOL make = (action == A_MAKE);
-			if (IS_NONE(arg) ||
-				(IS_LOGIC(arg) && !VAL_LOGIC(arg)) ||
-				(IS_INTEGER(arg) && (make && VAL_INT64(arg) == 0)) ||
-				((IS_DECIMAL(arg) || IS_PERCENT(arg)) && (make && VAL_DECIMAL(arg) == 0.0)) ||
-				(IS_MONEY(arg) && (make && deci_is_zero(VAL_DECI(arg))))
-			) goto is_false;
-			goto is_true;
-		}
+		// As a "Rebol conversion", TO falls in line with the rest of the
+		// interpreter canon that all non-none non-logic values are
+		// considered effectively "truth".  As a construction routine,
+		// MAKE takes more liberties in the meaning of its parameters,
+		// so it lets zero values be false.
+		if (IS_NONE(arg) ||
+			(IS_LOGIC(arg) && !VAL_LOGIC(arg)) ||
+			(IS_INTEGER(arg) && (action == A_MAKE && VAL_INT64(arg) == 0)) ||
+			((IS_DECIMAL(arg) || IS_PERCENT(arg)) && (action == A_MAKE && VAL_DECIMAL(arg) == 0.0)) ||
+			(IS_MONEY(arg) && (action == A_MAKE && deci_is_zero(VAL_DECI(arg))))
+		) goto is_false;
+		goto is_true;
 
 #ifdef removed
 	case A_CHANGE:


### PR DESCRIPTION
A minor adaptation of #164 to avoid the extra scoping blocks. No functional difference to #164.

The full original #164 PR message, for reference:

> Very simple change implementing the idea ([CC #2055](http://issue.cc/r3/2055)) that things like TO LOGIC! 0 are TRUE, while things like MAKE LOGIC! 0 remains false.  The converse is that TO INTEGER! TRUE or TO INTEGER! FALSE return errors, while MAKE INTEGER! TRUE returns 1 and MAKE INTEGER! FALSE returns 0.
> 
> Does not remove the `true?` or `found?` mezzanines, as consensus on that did not seem to have been reached, and @earl believes that `true? x` can read better than `to logic! x`.  Separate ticket(s) should be opened for those issues.
> 
> Tree core-tests affected:
> - `[false = to logic! 0]` [link](https://github.com/rebolsource/rebol-test/blob/master/core-tests.r#L1793)
> - `[0 = to integer! false]` [link](https://github.com/rebolsource/rebol-test/blob/master/core-tests.r#L1692)
> - `[1 = to integer! true]` [link](https://github.com/rebolsource/rebol-test/blob/master/core-tests.r#L1693)
