### PR TITLE
Fix a regression in PARSE caused by 8db79a9

### DIFF
--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -792,7 +792,7 @@ bad_target:
 				// word: - if not the target of a COPY or SET operation, this will
 				// default to setting a variable to the series at current index
 				if (IS_SET_WORD(item) &&
-					!GET_FLAG(flags, PF_SET_OR_COPY) || GET_FLAG(flags, PF_COPY))
+					!(GET_FLAG(flags, PF_SET_OR_COPY) || GET_FLAG(flags, PF_COPY)))
 				{
 					Set_Var_Series(item, parse->type, series, index);
 					continue;


### PR DESCRIPTION
This fixes an operator precedence typo in the check for "not COPY or SET" (introduced by 8db79a9 from PR #165) which causes a few regressions in PARSE.

Tested under Linux-x86: eliminates the 25 regressions.
