### PR TITLE
Fix evaluation of lit-words, lit-paths and set-paths

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -837,7 +837,6 @@ reval:
 		if (IS_UNSET(value)) Trap1(RE_NO_VALUE, word);
 		if (VAL_TYPE(value) >= REB_NATIVE && VAL_TYPE(value) <= REB_FUNCTION) goto reval; // || IS_LIT_PATH(value)
 		DS_PUSH(value);
-		if (IS_LIT_WORD(value)) VAL_SET(DS_TOP, REB_WORD);
 		if (IS_FRAME(value)) Init_Obj_Value(DS_TOP, VAL_WORD_FRAME(word));
 		index++;
 		break;

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -522,12 +522,12 @@ got_err:
 		else DO_BLK(value);
 		return R_TOS1;
 
-    case REB_NATIVE:
+	case REB_NATIVE:
 	case REB_ACTION:
-    case REB_COMMAND:
-    case REB_REBCODE:
-    case REB_OP:
-    case REB_CLOSURE:
+	case REB_COMMAND:
+	case REB_REBCODE:
+	case REB_OP:
+	case REB_CLOSURE:
 	case REB_FUNCTION:
 		VAL_SET_OPT(value, OPTS_REVAL);
 		return R_ARG1;
@@ -542,6 +542,11 @@ got_err:
 	case REB_LIT_WORD:
 		*D_RET = *value;
 		SET_TYPE(D_RET, REB_WORD);
+		return R_RET;
+
+	case REB_LIT_PATH:
+		*D_RET = *value;
+		SET_TYPE(D_RET, REB_PATH);
 		return R_RET;
 
 	case REB_ERROR:
@@ -561,6 +566,7 @@ got_err:
 		return R_ARG1;
 
 	case REB_SET_WORD:
+	case REB_SET_PATH:
 		Trap_Arg(value);
 
 	default:

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -31,9 +31,11 @@ make-port*: func [
 		url? spec [
 			spec: repend decode-url spec [to set-word! 'ref spec]
 			name: select spec to set-word! 'scheme
+			if lit-word? name [name: to word! name]
 		]
 		block? spec [
 			name: select spec to set-word! 'scheme
+			if lit-word? name [name: to word! name]
 		]
 		object? spec [
 			name: get in spec 'scheme


### PR DESCRIPTION
- Make inline evaluation of lit-word assigned to word return lit-word
- Make explicit evaluation of lit-path return path
- Make explicit evaluation of set-path trigger same error as set-word
- Fixes indentation style inconsistency in n-control.c
- Changed conversion in sys-ports.r from implicit to explicit

Fixes http://issue.cc/r3/1434 and http://issue.cc/r3/1883
