### PR TITLE
-fixed the infamous #9910 crash

### DIFF
--- a/src/tools/make-os-ext.r
+++ b/src/tools/make-os-ext.r
@@ -130,7 +130,8 @@ process: func [file] [
 remit {
 typedef struct REBOL_Host_Lib ^{
 	int size;
-	unsigned int ver_sum;}
+	unsigned int ver_sum;
+	REBDEV **devices;}
 
 memit {
 extern	REBOL_HOST_LIB *Host_Lib;
@@ -152,6 +153,7 @@ out: reduce [
 #define HOST_LIB_SUM } checksum/tcp to-binary xsum {
 #define HOST_LIB_SIZE } cnt {
 
+extern REBDEV *Devices[];
 }
 rlib
 {
@@ -169,6 +171,7 @@ REBOL_HOST_LIB *Host_Lib;
 REBOL_HOST_LIB Host_Lib_Init = ^{  // Host library function vector table.
 	HOST_LIB_SIZE,
 	(HOST_LIB_VER << 16) + HOST_LIB_SUM,
+	(REBDEV**)&Devices,
 }
 dlib
 {^};


### PR DESCRIPTION
the #9910 crash was caused by ports in pending requests being GCed while the system port or app code could still access the pending events with port refs

To test the crash you can run following gist: https://gist.github.com/cyphre/9122095

related addition:
-added Host_Lib->devices reference to be able access host Devices array from core dll

And thanks must go to Ladislav as well as he assisted me when looking up the best solution for the fix.
