### PR TITLE
Non-copying FUNC-BOOT for all mezzanines + explicitly distinct from FUNC

### DIFF
--- a/src/mezz/base-debug.r
+++ b/src/mezz/base-debug.r
@@ -16,7 +16,7 @@ REBOL [
 	}
 ]
 
-probe: func [
+probe: func-boot [
 	{Debug print a molded value and returns that same value.}
 	value [any-type!]
 ][
@@ -24,7 +24,7 @@ probe: func [
 	:value
 ]
 
-??: func [
+??: func-boot [
 	{Debug print a word, path, or block of such, followed by its molded value.}
 	'name "Word, path, and block to obtain values."
 	/local out
@@ -55,14 +55,14 @@ probe: func [
 	:name
 ]
 
-boot-print: func [
+boot-print: func-boot [
 	"Prints during boot when not quiet."
 	data
 ][
 	unless system/options/quiet [print :data]
 ]
 
-loud-print: func [
+loud-print: func-boot [
 	"Prints during boot when verbose."
 	data
 ][

--- a/src/mezz/base-defs.r
+++ b/src/mezz/base-defs.r
@@ -36,7 +36,7 @@ use [word title] [
 			values      ["object or module"]
 			types title ["function"] ; title should include module Title too...
 		] ["function, object, or module"]] ; body, words
-		set word func
+		set word func-boot
 			reduce [title 'value]
 			compose [reflect :value (to lit-word! name)]
 	]
@@ -90,57 +90,57 @@ system/options/result-types: make typeset! [
 
 ;-- Create "To-Datatype" conversion functions early in bootstrap:
 
-any-block?: func [
+any-block?: func-boot [
 	"Return TRUE if value is any type of block."
 	value [any-type!]
 ][find any-block! type? :value]
 
-any-string?: func [
+any-string?: func-boot [
 	"Return TRUE if value is any type of string."
 	value [any-type!]
 ][find any-string! type? :value]
 
-any-function?: func [
+any-function?: func-boot [
 	"Return TRUE if value is any type of function."
 	value [any-type!]
 ][find any-function! type? :value]
 
-any-word?: func [
+any-word?: func-boot [
 	"Return TRUE if value is any type of word."
 	value [any-type!]
 ][find any-word! type? :value]
 
-any-path?: func [
+any-path?: func-boot [
 	"Return TRUE if value is any type of path."
 	value [any-type!]
 ][find any-path! type? :value]
 
-any-object?: func [
+any-object?: func-boot [
 	"Return TRUE if value is any type of object."
 	value [any-type!]
 ][find any-object! type? :value]
 
-number?: func [
+number?: func-boot [
 	"Return TRUE if value is a number (integer or decimal)."
 	value [any-type!]
 ][find number! type? :value]
 
-series?: func [
+series?: func-boot [
 	"Return TRUE if value is any type of series."
 	value [any-type!]
 ][find series! type? :value]
 
-scalar?: func [
+scalar?: func-boot [
 	"Return TRUE if value is any type of scalar."
 	value [any-type!]
 ][find scalar! type? :value]
 
-true?: func [
+true?: func-boot [
 	"Returns true if an expression can be used as true."
 	val ; Note: No [any-type!] - we want unset! to fail.
 ] [not not :val]
 
-quote: func [
+quote: func-boot [
 	"Returns the value passed to it without evaluation."
 	:value [any-type!]
 ] [

--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -16,21 +16,21 @@ REBOL [
 	}
 ]
 
-info?: func [
+info?: func-boot [
 	{Returns an info object about a file or url.}
 	target [file! url!]
 ][
 	query target
 ]
 
-exists?: func [
+exists?: func-boot [
 	{Returns the type of a file or URL if it exists, otherwise none.}
 	target [file! url!]
 ][ ; Returns 'file or 'dir, or none
 	select attempt [query target] 'type
 ]
 
-size?: func [
+size?: func-boot [
 	{Returns the size of a file.}
 	target [file! url!]
 ][
@@ -40,7 +40,7 @@ size?: func [
 	]
 ]
 
-modified?: func [
+modified?: func-boot [
 	{Returns the last modified date of a file.}
 	target [file! url!]
 ][
@@ -50,7 +50,7 @@ modified?: func [
 	]
 ]
 
-suffix?: func [
+suffix?: func-boot [
 	"Return the file suffix of a filename or url. Else, NONE."
 	path [file! url! string!]
 ][
@@ -60,14 +60,14 @@ suffix?: func [
 	][to file! path]
 ]
 
-dir?: func [
+dir?: func-boot [
 	{Returns TRUE if the file or url ends with a slash (or backslash).}
 	target [file! url!]
 ][
 	true? find "/\" last target
 ]
 
-dirize: func [
+dirize: func-boot [
 	{Returns a copy (always) of the path as a directory (ending slash).}
 	path [file! string! url!]
 ][
@@ -76,7 +76,7 @@ dirize: func [
 	path
 ]
 
-make-dir: func [
+make-dir: func-boot [
 	"Creates the specified directory. No error if already exists."
 	path [file! url!]
 	/deep "Create subdirectories too"
@@ -124,7 +124,7 @@ make-dir: func [
 	path
 ]
 
-delete-dir: func [
+delete-dir: func-boot [
 	{Deletes a directory including all files and subdirectories.}
 	dir [file! url!]
 	/local files
@@ -139,7 +139,7 @@ delete-dir: func [
 	attempt [delete dir]
 ]
 
-script?: func [
+script?: func-boot [
 	{Checks file, url, or string for a valid script header.}
 	source [file! url! binary! string!]
 ][
@@ -150,14 +150,14 @@ script?: func [
 	find-script source ; Returns binary!
 ]
 
-file-type?: func [
+file-type?: func-boot [
 	"Return the identifying word for a specific file type (or NONE)."
 	file [file! url!]
 ][
 	if file: find find system/options/file-types suffix? file word! [first file]
 ]
 
-split-path: func [
+split-path: func-boot [
 	"Splits and returns directory path and file as a block."
 	target [file! url! string!]
 	/local dir pos
@@ -172,22 +172,25 @@ split-path: func [
 	reduce [dir pos]
 ]
 
-intern: function [
+intern: func-boot [
 	"Imports (internalize) words and their values from the lib into the user context."
 	data [block! any-word!] "Word or block of words to be added (deeply)"
+	/local index usr
 ][
-	index: 1 + length? usr: system/contexts/user ; optimization
+	; index for resolve (for optimization below)
+	index: 1 + length? usr: system/contexts/user 
 	data: bind/new :data usr   ; Extend the user context with new words
 	resolve/only usr lib index ; Copy only the new values into the user context
 	:data
 ]
 
-load: function [
+load-boot: func-boot [
 	{Simple load of a file, URL, or string/binary - minimal boot version.}
 	source [file! url! string! binary!]
 	/header  {Includes REBOL header object if present}
 	/all     {Load all values, including header (as block)}
 	;/unbound {Do not bind the block}
+	/local data hdr?
 ][
 	if string? data: case [
 		file? source [read source]

--- a/src/mezz/base-funcs.r
+++ b/src/mezz/base-funcs.r
@@ -16,53 +16,61 @@ REBOL [
 	}
 ]
 
-func: make function! [[
-	; !!! This is a special minimal FUNC for more efficient boot. Gets replaced later in boot.
+;-- Reserve FUNC word early in the system context, but make it error if you
+;-- try to invoke the copying-body semantics until we run %mezz-tail.r
+func: make function! [[spec body] [
+	print "FUNC primitive used in Mezzanine, use FUNC-BOOT!"
+	print mold spec
+	print mold body
+	exit
+]]
+
+func-boot: make function! [[
+	;
+	; The boot function generator does not copy the body.  This makes it not
+	; suitable for situations like:
+	;
+	;     body: [
+	;         value: {}
+	;         append value {text}
+	;         return value
+	;     ]
+	; 
+	;     x: func-boot [] body
+	;     insert body [print "Entering y function"]
+	;     y: func-boot [] body
+	;
+	;     x
+	;     y
+	;
+	; Since the func-boot generator does not copy the body, this would mean the
+	; output would be:
+	;
+	;     Entering y function
+	;     text
+	;     Entering y function
+	;     texttext
+	;
+	; The Mezzanine loads faster by using the non-copying version, since it
+	; does not run into this situation.  We don't want to expose that to the
+	; average user, however, so after the Mezzanine hits %mezz-tail.r we
+	; define it to cause an error.
+	;
 	{Non-copying function constructor (optimized for boot).}
 	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
 	body [block!] {The body block of the function}
 ][
-	make function! reduce [spec body]
+	make function! protect/deep reduce [spec body]
 ]]
 
-function: funct: func [
-	{Defines a function with all set-words as locals.}
-	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
-	body [block!] {The body block of the function}
-	/with {Define or use a persistent object (self)}
-	object [object! block! map!] {The object or spec}
-	/extern words [block!] {These words are not local}
-][
-	; Copy the spec and add /local to the end if not found
-	unless find spec: copy/deep spec /local [append spec [
-		/local ; In a block so the generated source gets the newlines
-	]]
-	; Make a full copy of the body, to allow reuse of the original
-	body: copy/deep body
-	; Collect all set-words in the body as words to be used as locals, and add
-	; them to the spec. Don't include the words already in the spec or object.
-	append spec collect-words/deep/set/ignore body either with [
-		; Make our own local object if a premade one is not provided
-		unless object? object [object: make object! object]
-		bind body object  ; Bind any object words found in the body
-		; Ignore the words in the spec and those in the object. The spec needs
-		; to be copied since the object words shouldn't be added to the locals.
-		append append append copy spec 'self words-of object words ; ignore 'self too
-	][
-		; Don't include the words in the spec, or any extern words.
-		either extern [append copy spec words] [spec]
-	]
-	make function! reduce [spec body]
-]
-
-does: func [
+does: func-boot [
 	{A shortcut to define a function that has no arguments or locals.}
 	body [block!] {The body block of the function}
 ][
 	make function! copy/deep reduce [[] body]
 ]
 
-use: func [
+use: func-boot [
 	{Defines words local to a block.}
 	vars [block! word!] {Local word(s) to the block}
 	body [block!] {Block to evaluate}
@@ -70,14 +78,14 @@ use: func [
 	apply make closure! reduce [to block! vars copy/deep body] []
 ]
 
-object: func [
+object: func-boot [
 	{Defines a unique object.}
 	blk [block!] {Object words and values (modified)}
 ][
 	make object! append blk none
 ]
 
-module: func [
+module: func-boot [
 	"Creates a new module."
 	spec [block!] "The header block of the module (modified)"
 	body [block!] "The body block of the module (modified)"
@@ -87,7 +95,7 @@ module: func [
 	make module! unbind/deep reduce pick [[spec body] [spec body words]] not mixin
 ]
 
-cause-error: func [
+cause-error: func-boot [
 	"Causes an immediate error throw with the provided information."
 	err-type [word!]
 	err-id [word!]
@@ -111,7 +119,7 @@ cause-error: func [
 	]
 ]
 
-default: func [
+default: func-boot [
 	"Set a word to a default value if it hasn't been set yet."
 	'word [word! set-word! lit-word!] "The word (use :var for word! values)"
 	value "The value" ; unset! not allowed on purpose
@@ -119,5 +127,5 @@ default: func [
 	unless all [value? word not none? get word] [set word :value] :value
 ]
 
-secure: func ['d] [boot-print "SECURE is disabled"]
+secure: func-boot ['d] [boot-print "SECURE is disabled"]
 

--- a/src/mezz/base-series.r
+++ b/src/mezz/base-series.r
@@ -16,7 +16,7 @@ REBOL [
 	}
 ]
 
-repend: func [
+repend: func-boot [
 	"Appends a reduced value to a series and returns the series head."
 	series [series! port! map! gob! object! bitset!] {Series at point to insert (modified)}
 	value {The value to insert}
@@ -29,7 +29,7 @@ repend: func [
 	apply :append [series reduce :value part length only dup count]
 ]
 
-join: func [
+join: func-boot [
 	"Concatenates values."
 	value "Base value"
 	rest "Value or block of values"
@@ -38,7 +38,7 @@ join: func [
 	repend value :rest
 ]
 
-reform: func [
+reform: func-boot [
 	"Forms a reduced block and returns a string."
 	value "Value to reduce and form"
 	;/with "separator"

--- a/src/mezz/boot-files.r
+++ b/src/mezz/boot-files.r
@@ -34,7 +34,6 @@ REBOL [
 ;-- lib: mid-level lib context:
 [
 	%mezz-types.r
-	%mezz-func.r
 	%mezz-debug.r
 	%mezz-control.r
 	%mezz-save.r
@@ -42,10 +41,11 @@ REBOL [
 	%mezz-files.r
 	%mezz-shell.r
 	%mezz-math.r
-	%mezz-help.r ; move dump-obj!
+	%mezz-help.r
 	%mezz-banner.r
 	%mezz-colors.r
-	%mezz-tail.r
+	%mezz-func.r
+	%mezz-tail.r ; move dump-obj!
 ]
 
 ;-- protocols:

--- a/src/mezz/mezz-banner.r
+++ b/src/mezz/mezz-banner.r
@@ -11,7 +11,7 @@ REBOL [
 	}
 ]
 
-make-banner: func [
+make-banner: func-boot [
 	"Build startup banner."
 	fmt /local str star spc a b s
 ][

--- a/src/mezz/mezz-control.r
+++ b/src/mezz/mezz-control.r
@@ -11,7 +11,7 @@ REBOL [
 	}
 ]
 
-launch: func [
+launch: func-boot [
 	{Runs a script as a separate process; return immediately.}
 	script [file! string! none!] "The name of the script"
 	/args arg [string! block! none!] "Arguments to the script"

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -11,16 +11,17 @@ REBOL [
 	}
 ]
 
-dt: delta-time: function [
+dt: delta-time: func-boot [
 	{Delta-time - returns the time it takes to evaluate the block.}
 	block [block!]
+	/local start
 ][
 	start: stats/timer
 	do block
 	stats/timer - start
 ]
 
-dp: delta-profile: func [
+dp: delta-profile: func-boot [
 	{Delta-profile of running a specific block.}
 	block [block!]
 	/local start end
@@ -37,10 +38,11 @@ dp: delta-profile: func [
 	start
 ]
 
-speed?: function [
+speed?: func-boot [
 	"Returns approximate speed benchmarks [eval cpu memory file-io]."
 	/no-io "Skip the I/O test"
 	/times "Show time for each test"
+	/local calc tmp secs
 ][
 	result: copy []
 	foreach block [

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -11,7 +11,7 @@ REBOL [
 	}
 ]
 
-clean-path: func [
+clean-path: func-boot [
 	"Returns new directory path with //, . and .. processed."
 	file [file! url! string!]
 	/only "Do not prepend current directory"
@@ -62,9 +62,10 @@ clean-path: func [
 	reverse out
 ]
 
-input: function [
+input: func-boot [
 	{Inputs a string from the console. New-line character is removed.}
 ;	/hide "Mask input with a * character"
+	/local line
 ][
 	if any [
 		not port? system/ports/input
@@ -77,7 +78,7 @@ input: function [
 	line
 ]
 
-ask: func [
+ask: func-boot [
 	"Ask the user for input."
 	question [series!] "Prompt to user"
 	/hide "mask input with *"
@@ -86,7 +87,7 @@ ask: func [
 	trim either hide [input/hide] [input]
 ]
 
-confirm: func [
+confirm: func-boot [
 	"Confirms a user choice."
 	question [series!] "Prompt to user"
 	/with choices [string! block!]
@@ -106,7 +107,7 @@ confirm: func [
 	]
 ]
 
-list-dir: func [
+list-dir: func-boot [
 	"Print contents of a directory (ls)."
 	'path [file! word! path! string! unset!] "Accepts %file, :variables, and just words (as dirs)"
 	/l "Line of info format"
@@ -152,7 +153,7 @@ list-dir: func [
 	exit
 ]
 
-undirize: func [
+undirize: func-boot [
 	{Returns a copy of the path with any trailing "/" removed.}
 	path [file! string! url!]
 ][
@@ -161,7 +162,7 @@ undirize: func [
 	path
 ]
 
-in-dir: func [
+in-dir: func-boot [
 	"Evaluate a block while in a directory."
 	dir [file!] "Directory to change to (changed back after)"
 	block [block!] "Block to evaluate"
@@ -172,7 +173,7 @@ in-dir: func [
 	also do block change-dir old-dir
 ] ; You don't want the block to be done if the change-dir fails, for safety.
 
-to-relative-file: func [
+to-relative-file: func-boot [
 	"Returns the relative portion of a file if in a subdirectory, or the original if not."
 	file [file! string!] "File to check (local if string!)"
 	/no-copy "Don't copy, just reference"

--- a/src/mezz/mezz-func.r
+++ b/src/mezz/mezz-func.r
@@ -11,7 +11,49 @@ REBOL [
 	}
 ]
 
-clos: func [
+func: func-boot [
+	{Defines a user function with given spec and body.}
+	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
+	body [block!] {The body block of the function}
+][
+	make function! copy/deep reduce [spec body] ; (deep copies, unlike func-boot)
+]
+
+function: func-boot [
+	{Defines a function with all set-words as locals.}
+	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
+	body [block!] {The body block of the function}
+	/with {Define or use a persistent object (self)}
+	object [object! block! map!] {The object or spec}
+	/extern words [block!] {These words are not local}
+][
+	; Copy the spec and add /local to the end if not found
+	unless find spec: copy/deep spec /local [append spec [
+		/local ; In a block so the generated source gets the newlines
+	]]
+	; Make a full copy of the body, to allow reuse of the original
+	body: copy/deep body
+	; Collect all set-words in the body as words to be used as locals, and add
+	; them to the spec. Don't include the words already in the spec or object.
+	append spec collect-words/deep/set/ignore body either with [
+		; Make our own local object if a premade one is not provided
+		unless object? object [object: make object! object]
+		bind body object  ; Bind any object words found in the body
+		; Ignore the words in the spec and those in the object. The spec needs
+		; to be copied since the object words shouldn't be added to the locals.
+		append append append copy spec 'self words-of object words ; ignore 'self too
+	][
+		; Don't include the words in the spec, or any extern words.
+		either extern [append copy spec words] [spec]
+	]
+	make function! reduce [spec body]
+]
+
+;-- Alias for FUNCTION for historical compatibility
+;-- (should be in R3/Backward, not in core)
+funct: :function
+
+clos: func-boot [
 	{Defines a closure function.}
 	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
 	body [block!] {The body block of the function}
@@ -19,7 +61,7 @@ clos: func [
 	make closure! copy/deep reduce [spec body]
 ]
 
-closure: func [
+closure: func-boot [
 	{Defines a closure function with all set-words as locals.}
 	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
 	body [block!] {The body block of the function}
@@ -49,7 +91,7 @@ closure: func [
 	make closure! reduce [spec body]
 ]
 
-has: func [
+has: func-boot [
 	{A shortcut to define a function that has local variables but no arguments.}
 	vars [block!] {List of words that are local to the function}
 	body [block!] {The body block of the function}
@@ -57,21 +99,21 @@ has: func [
 	make function! reduce [head insert copy/deep vars /local copy/deep body]
 ]
 
-context: func [
+context: func-boot [
 	{Defines a unique object.}
 	blk [block!] {Object words and values (modified)}
 ][
 	make object! blk
 ]
 
-map: func [
+map: func-boot [
 	{Make a map value (hashed associative block).}
 	val
 ][
 	make map! :val
 ]
 
-task: func [
+task: func-boot [
 	{Creates a task.}
 	spec [block!] {Name or spec block}
 	body [block!] {The body block of the task}

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -147,7 +147,7 @@ REBOL [
 	]
 
 	; Print type name with proper singular article:
-	type-name: func-boot [value] [
+	type-name: func [value] [
 		value: mold type? :value
 		clear back tail value
 		join either find "aeiou" first value ["an "]["a "] value
@@ -202,7 +202,7 @@ REBOL [
 	clear find args /local
 
 	;-- Print arg lists:
-	print-args: func-boot [label list /extra /local str] [
+	print-args: func [label list /extra /local str] [
 		if empty? list [exit]
 		print label
 		foreach arg list [

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -11,91 +11,14 @@ REBOL [
 	}
 ]
 
-; MOVE THIS INTERNAL FUNC:
-dump-obj: function [
-	"Returns a block of information about an object or port."
-	obj [object! port!]
-	/match "Include only those that match a string or datatype" pat
-][
-	clip-str: func [str] [
-		; Keep string to one line.
-		trim/lines str
-		if (length? str) > 45 [str: append copy/part str 45 "..."]
-		str
-	]
-
-	form-val: func [val] [
-		; Form a limited string from the value provided.
-		if any-block? :val [return reform ["length:" length? val]]
-		if image? :val [return reform ["size:" val/size]]
-		if datatype? :val [return get in spec-of val 'title]
-		if any-function? :val [
-			return clip-str any [title-of :val mold spec-of :val]
-		]
-		if object? :val [val: words-of val]
-		if typeset? :val [val: to-block val]
-		if port? :val [val: reduce [val/spec/title val/spec/ref]]
-		if gob? :val [return reform ["offset:" val/offset "size:" val/size]]
-		clip-str mold :val
-	]
-
-	form-pad: func [val size] [
-		; Form a value with fixed size (space padding follows).
-		val: form val
-		insert/dup tail val #" " size - length? val
-		val
-	]
-
-	; Search for matching strings:
-	out: copy []
-	wild: all [string? pat  find pat "*"]
-
-	foreach [word val] obj [
-		type: type?/word :val
-		str: either find [function! closure! native! action! op! object!] type [
-			reform [word mold spec-of :val words-of :val]
-		][
-			form word
-		]
-		if any [
-			not match
-			all [
-				not unset? :val
-				either string? :pat [
-					either wild [
-						tail? any [find/any/match str pat pat]
-					][
-						find str pat
-					]
-				][
-					all [
-						datatype? get :pat
-						type = :pat
-					]
-				]
-			]
-		][
-			str: form-pad word 15
-			append str #" "
-			append str form-pad type 10 - ((length? str) - 15)
-			append out reform [
-				"  " str
-				if type <> 'unset! [form-val :val]
-				newline
-			]
-		]
-	]
-	out
-]
-
-?: help: func [
+?: help: func-boot [
 	"Prints information about words and values."
 	'word [any-type!]
 	/doc "Open web browser to related documentation."
 	/local value args item type-name types tmp print-args
 ][
 	if unset? get/any 'word [
-		print trim/auto {
+		print trim/auto copy {
 			Use HELP or ? to see built-in info:
 
 				help insert
@@ -224,7 +147,7 @@ dump-obj: function [
 	]
 
 	; Print type name with proper singular article:
-	type-name: func [value] [
+	type-name: func-boot [value] [
 		value: mold type? :value
 		clear back tail value
 		join either find "aeiou" first value ["an "]["a "] value
@@ -279,7 +202,7 @@ dump-obj: function [
 	clear find args /local
 
 	;-- Print arg lists:
-	print-args: func [label list /extra /local str] [
+	print-args: func-boot [label list /extra /local str] [
 		if empty? list [exit]
 		print label
 		foreach arg list [
@@ -314,7 +237,7 @@ dump-obj: function [
 	exit ; return unset
 ]
 
-about: func [
+about: func-boot [
 	"Information about REBOL"
 ][
 	print make-banner sys/boot-banner
@@ -322,10 +245,10 @@ about: func [
 
 ;		--cgi (-c)       Load CGI utiliy module and modes
 
-usage: func [
+usage: func-boot [
 	"Prints command-line arguments."
 ][
-	print trim/auto {
+	print trim/auto copy {
 	Command line usage:
 
 		REBOL |options| |script| |arguments|
@@ -364,13 +287,13 @@ usage: func [
 	}
 ]
 
-license: func [
+license: func-boot [
 	"Prints the REBOL/core license agreement."
 ][
 	print system/license
 ]
 
-source: func [
+source: func-boot [
 	"Prints the source code for a word."
 	'word [word! path!]
 ][
@@ -379,7 +302,7 @@ source: func [
 	exit
 ]
 
-what: func [
+what: func-boot [
 	{Prints a list of known functions.}
 	'name [word! lit-word! unset!] "Optional module name"
 	/args "Show arguments not titles"
@@ -412,17 +335,17 @@ what: func [
 	exit
 ]
 
-pending: does [
+pending: func-boot [] [
 	comment "temp function"
 	print "Pending implementation."
 ]
 
-say-browser: does [
+say-browser: func-boot [] [
 	comment "temp function"
 	print "Opening web browser..."
 ]
 
-upgrade: function [
+upgrade: func-boot [/local err] [
 	"Check for newer versions (update REBOL)."
 ][
 	print "Fetching upgrade check ..."
@@ -432,7 +355,7 @@ upgrade: function [
 	exit
 ]
 
-chat: function [
+chat: func-boot [/local err] [
 	"Open REBOL DevBase forum/BBS."
 ][
 	print "Fetching chat..."
@@ -442,7 +365,7 @@ chat: function [
 	exit
 ]
 
-docs: func [
+docs: func-boot [
 	"Browse on-line documentation."
 ][
 	say-browser
@@ -450,7 +373,7 @@ docs: func [
 	exit
 ]
 
-bugs: func [
+bugs: func-boot [
 	"View bug database."
 ][
 	say-browser
@@ -458,7 +381,7 @@ bugs: func [
 	exit
 ]
 
-changes: func [
+changes: func-boot [
 	"What's new about this version."
 ][
 	say-browser
@@ -466,7 +389,7 @@ changes: func [
 	exit
 ]
 
-why?: func [
+why?: func-boot [
 	"Explain the last error in more detail."
 	'err [word! path! error! none! unset!] "Optional error value"
 ][
@@ -489,8 +412,9 @@ why?: func [
 	exit
 ]
 
-demo: function [
+demo: func-boot [
 	"Run R3 demo."
+	/local err
 ][
 	print "Fetching demo..."
 	if error? err: try [do http://www.rebol.com/r3/demo.r none][
@@ -499,8 +423,9 @@ demo: function [
 	exit
 ]
 
-load-gui: function [
+load-gui: func-boot [
 	"Download current GUI module from web. (Temporary)"
+	/local data
 ][
 	print "Fetching GUI..."
 	either error? data: try [load http://www.rebol.com/r3/gui.r][

--- a/src/mezz/mezz-math.r
+++ b/src/mezz/mezz-math.r
@@ -11,7 +11,7 @@ REBOL [
 	}
 ]
 
-mod: func [
+mod: func-boot [
 	"Compute a nonnegative remainder of A divided by B."
 	; In fact the function tries to find the remainder,
 	; that is "almost non-negative"
@@ -31,7 +31,7 @@ mod: func [
 	either all [a + r = (a + b)  positive? r + r - b] [r - b] [r]
 ]
 
-modulo: func [
+modulo: func-boot [
 	{Wrapper for MOD that handles errors like REMAINDER. Negligible values (compared to A and B) are rounded to zero.}
 	;[catch]
 	a [number! money! time!]
@@ -48,7 +48,7 @@ modulo: func [
 	either any [a - r = a   r + b = b] [make r 0] [r]
 ]
 
-sign?: func [
+sign?: func-boot [
 	"Returns sign of number as 1, 0, or -1 (to use as multiplier)."
 	number [number! money! time!]
 ][
@@ -59,7 +59,7 @@ sign?: func [
 	]
 ]
 
-minimum-of: func [
+minimum-of: func-boot [
 	{Finds the smallest value in a series}
 	series [series!] {Series to search}
 	/skip {Treat the series as records of fixed size}
@@ -75,7 +75,7 @@ minimum-of: func [
 	spot
 ]
 
-maximum-of: func [
+maximum-of: func-boot [
 	{Finds the largest value in a series}
 	series [series!] {Series to search}
 	/skip {Treat the series as records of fixed size}

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -15,7 +15,7 @@ REBOL [
 	}
 ]
 
-mold64: function [
+mold64: func-boot [
 	"Temporary function to mold binary base 64." ; fix the need for this! -CS
 	data
 ][
@@ -26,7 +26,7 @@ mold64: function [
 	data
 ]
 
-save: function [
+save: func-boot [
 	{Saves a value, block, or other data to a file, URL, binary, or string.}
 	where [file! url! binary! string! none!] {Where to save (suffix determines encoding)}
 	value {Value(s) to save}
@@ -36,6 +36,7 @@ save: function [
 	/length {Save the length of the script content in the header}
 	/compress {Save in a compressed format or not}
 	method [logic! word!] "true = compressed, false = not, 'script = encoded string"
+	/local data tmp
 ][
 	;-- Special datatypes use codecs directly (e.g. PNG image file):
 	if lib/all [

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -18,7 +18,7 @@ empty?: make :tail? [
 	]
 ]
 
-offset?: func [
+offset?: func-boot [
 	"Returns the offset between two series positions."
 	series1 [series!]
 	series2 [series!]
@@ -26,21 +26,21 @@ offset?: func [
 	subtract index? series2 index? series1
 ]
 
-found?: func [
+found?: func-boot [
 	"Returns TRUE if value is not NONE."
 	value
 ][
 	not none? :value
 ]
 
-last?: single?: func [
+last?: single?: func-boot [
 	"Returns TRUE if the series length is 1."
 	series [series! port! map! tuple! bitset! object! gob! any-word!]
 ][
 	1 = length? series
 ]
 
-extend: func [
+extend: func-boot [
 	"Extend an object, map, or block type with word and value pair."
 	obj [object! map! block! paren!] {object to extend (modified)}
 	word [any-word!]
@@ -50,7 +50,7 @@ extend: func [
 	:val
 ]
 
-rejoin: func [
+rejoin: func-boot [
 	"Reduces and joins a block of values."
 	block [block!] "Values to reduce and join"
 	;/with "separator"
@@ -61,7 +61,7 @@ rejoin: func [
 	] next block
 ]
 
-remold: func [
+remold: func-boot [
 	{Reduces and converts a value to a REBOL-readable string.}
 	value {The value to reduce and mold}
 	/only {For a block value, mold only its contents, no outer []}
@@ -71,7 +71,7 @@ remold: func [
 	apply :mold [reduce :value only all flat]
 ]
 
-charset: func [
+charset: func-boot [
 	"Makes a bitset of chars for the parse function."
 	chars [string! block! binary! char! integer!]
 	/length "Preallocate this many bits"
@@ -80,7 +80,7 @@ charset: func [
 	either length [append make bitset! len chars] [make bitset! chars]
 ]
 
-array: func [
+array: func-boot [
 	"Makes and initializes a series of a given size."
 	size [integer! block!] "Size or block of sizes for each dimension"
 	/initial "Specify an initial value for all elements"
@@ -109,7 +109,7 @@ array: func [
 	head block
 ]
 
-replace: func [
+replace: func-boot [
 	"Replaces a search value with the replace value within the target series."
 	target  [series!] "Series to replace within (modified)"
 	search  "Value to be replaced (converted if necessary)"
@@ -150,7 +150,7 @@ replace: func [
 ]
 ; We need to consider adding an /any refinement to use find/any, once that works.
 
-reword: func [
+reword: func-boot [
 	"Make a string or binary based on a template and substitution values."
 	source [any-string! binary!] "Template series with escape sequences"
 	values [map! object! block!] "Keyword literals and value expressions"
@@ -268,7 +268,7 @@ reword: func [
 ]
 ; It's big, it's complex, but it works. Placeholder for a native.
 
-move: func [
+move: func-boot [
 	"Move a value or span of values in a series."
 	source [series!] "Source series (modified)"
 	offset [integer!] "Offset to move by, or index to move to"
@@ -290,7 +290,7 @@ move: func [
 	] part
 ]
 
-extract: func [
+extract: func-boot [
 	"Extracts a value from a series at regular intervals."
 	series [series!]
 	width [integer!] "Size of each entry (the skip)"
@@ -328,7 +328,7 @@ extract: func [
 	either into [output] [head output]
 ]
 
-alter: func [
+alter: func-boot [
 	"Append value if not found, else remove it; returns true if added."
 	series [series! port! bitset!] {(modified)}
 	value
@@ -346,7 +346,7 @@ alter: func [
 	) [append series :value]
 ]
 
-collect: func [
+collect: func-boot [
 	"Evaluates a block, storing values via KEEP function, and returns block of collected values."
 	body [block!] "Block to evaluate"
 	/into "Insert into a buffer instead (returns position after insert)"
@@ -360,11 +360,12 @@ collect: func [
 	either into [output] [head output]
 ]
 
-format: function [
+format: func-boot [
 	"Format a string according to the format dialect."
 	rules {A block in the format dialect. E.g. [10 -10 #"-" 4]}
 	values
 	/pad p
+	/local val out 
 ][
 	p: any [p #" "]
 	unless block? :rules [rules: reduce [:rules]]
@@ -410,7 +411,7 @@ format: function [
 	head out
 ]
 
-printf: func [
+printf: func-boot [
 	"Formatted print."
 	fmt "Format"
 	val "Value or block of values"
@@ -418,7 +419,7 @@ printf: func [
 	print format :fmt :val
 ]
 
-split: func [
+split: func-boot [
 	"Split a series into pieces; fixed or variable size, fixed number, or at delimiters"
 	series	[series!] "The series to split"
 	dlm		[block! integer! char! bitset! any-string!] "Split size, delimiter(s), or rule(s)." 
@@ -501,7 +502,7 @@ split: func [
 	]
 ]
 
-find-all: func [
+find-all: func-boot [
 	"Find all occurrences of a value within a series (allows modification)."
 	'series [word!] "Variable for block, string, or other series"
 	value

--- a/src/mezz/mezz-shell.r
+++ b/src/mezz/mezz-shell.r
@@ -16,7 +16,7 @@ pwd:	:what-dir
 rm:		:delete
 mkdir:	:make-dir
 
-cd: func [
+cd: func-boot [
 	"Change directory (shell shortcut function)."
 	'path [file! word! path! unset! string!] "Accepts %file, :variables and just words (as dirs)"
 ][
@@ -28,7 +28,7 @@ cd: func [
 	]
 ]
 
-more: func [
+more: func-boot [
 	"Print file (shell shortcut function)."
 	'file [file! word! path! string!] "Accepts %file and also just words (as file names)"
 ][

--- a/src/mezz/mezz-tail.r
+++ b/src/mezz/mezz-tail.r
@@ -11,16 +11,99 @@ REBOL [
 	}
 ]
 
-funco: :func ; save it for expert usage
-
-; Final FUNC definition:
-func: funco [
-	{Defines a user function with given spec and body.}
-	spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
-	body [block!] {The body block of the function}
-][
-	make function! copy/deep reduce [spec body] ; (now it deep copies)
+;-- Remove FUNC-BOOT from client use.
+;-- (Note: experts who need this kind of control with their own function 
+;-- generators can use MAKE FUNCTION!, which does not copy.)
+func-boot: func [
+	{Internal function generator (not for client use)}
+	spec body
+] [
+    print "FUNC-BOOT should only be used in Mezzanine code"
+    probe spec
+    probe body
+    exit
 ]
+
+
+; MOVE THIS INTERNAL FUNCTION!
+dump-obj: func [
+	"Returns a block of information about an object or port."
+	obj [object! port!]
+	/match "Include only those that match a string or datatype" pat
+	/local str val out 
+][
+	clip-str: func-boot [str] [
+		; Keep string to one line.
+		trim/lines str
+		if (length? str) > 45 [str: append copy/part str 45 "..."]
+		str
+	]
+
+	form-val: func-boot [val] [
+		; Form a limited string from the value provided.
+		if any-block? :val [return reform ["length:" length? val]]
+		if image? :val [return reform ["size:" val/size]]
+		if datatype? :val [return get in spec-of val 'title]
+		if any-function? :val [
+			return clip-str any [title-of :val mold spec-of :val]
+		]
+		if object? :val [val: words-of val]
+		if typeset? :val [val: to-block val]
+		if port? :val [val: reduce [val/spec/title val/spec/ref]]
+		if gob? :val [return reform ["offset:" val/offset "size:" val/size]]
+		clip-str mold :val
+	]
+
+	form-pad: func-boot [val size] [
+		; Form a value with fixed size (space padding follows).
+		val: form val
+		insert/dup tail val #" " size - length? val
+		val
+	]
+
+	; Search for matching strings:
+	out: copy []
+	wild: all [string? pat  find pat "*"]
+
+	foreach [word val] obj [
+		type: type?/word :val
+		str: either find [function! closure! native! action! op! object!] type [
+			reform [word mold spec-of :val words-of :val]
+		][
+			form word
+		]
+		if any [
+			not match
+			all [
+				not unset? :val
+				either string? :pat [
+					either wild [
+						tail? any [find/any/match str pat pat]
+					][
+						find str pat
+					]
+				][
+					all [
+						datatype? get :pat
+						type = :pat
+					]
+				]
+			]
+		][
+			str: form-pad word 15
+			append str #" "
+			append str form-pad type 10 - ((length? str) - 15)
+			append out reform [
+				"  " str
+				if type <> 'unset! [form-val :val]
+				newline
+			]
+		]
+	]
+	out
+]
+
 
 ; Quick test runner (temporary):
 t: does [do %test.r]
+

--- a/src/mezz/mezz-tail.r
+++ b/src/mezz/mezz-tail.r
@@ -14,32 +14,23 @@ REBOL [
 ;-- Remove FUNC-BOOT from client use.
 ;-- (Note: experts who need this kind of control with their own function 
 ;-- generators can use MAKE FUNCTION!, which does not copy.)
-func-boot: func [
-	{Internal function generator (not for client use)}
-	spec body
-] [
-    print "FUNC-BOOT should only be used in Mezzanine code"
-    probe spec
-    probe body
-    exit
-]
+unset 'func-boot
 
 
 ; MOVE THIS INTERNAL FUNCTION!
-dump-obj: func [
+dump-obj: function [
 	"Returns a block of information about an object or port."
 	obj [object! port!]
 	/match "Include only those that match a string or datatype" pat
-	/local str val out 
 ][
-	clip-str: func-boot [str] [
+	clip-str: func [str] [
 		; Keep string to one line.
 		trim/lines str
 		if (length? str) > 45 [str: append copy/part str 45 "..."]
 		str
 	]
 
-	form-val: func-boot [val] [
+	form-val: func [val] [
 		; Form a limited string from the value provided.
 		if any-block? :val [return reform ["length:" length? val]]
 		if image? :val [return reform ["size:" val/size]]
@@ -54,7 +45,7 @@ dump-obj: func [
 		clip-str mold :val
 	]
 
-	form-pad: func-boot [val size] [
+	form-pad: func [val size] [
 		; Form a value with fixed size (space padding follows).
 		val: form val
 		insert/dup tail val #" " size - length? val

--- a/src/mezz/mezz-types.r
+++ b/src/mezz/mezz-types.r
@@ -28,7 +28,7 @@ use [word] [
 		; The list above determines what will be made here:
 		if in lib word: make word! head remove back tail ajoin ["to-" type] [
 			; Add doc line only if this build has autodocs:
-			set in lib :word func either string? first spec-of :make [
+			set in lib :word func-boot either string? first spec-of :make [
 				reduce [reform ["Converts to" form type "value."] 'value]
 			][
 				[value]

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -26,7 +26,7 @@ REBOL [
 native: none ; for boot only
 action: none ; for boot only
 
-do*: func [
+do*: func-boot [
 	{SYS: Called by system for DO on datatypes that require special handling.}
 	value [file! url! string! binary!]
 	/args "If value is a script, this will set its system/script/args"
@@ -100,7 +100,7 @@ do*: func [
 	]
 ]
 
-make-module*: func [
+make-module*: func-boot [
 	"SYS: Called by system on MAKE of MODULE! datatype."
 	spec [block!] "As [spec-block body-block opt-mixins-object]"
 	/local body obj mixins hidden w
@@ -196,16 +196,17 @@ boot-mezz: none ; built-in mezz code (put here on boot)
 boot-prot: none ; built-in boot protocols
 boot-exts: none ; boot extension list
 
-export: func [
+export: func-boot [
 	"Low level export of values (e.g. functions) to lib."
 	words [block!] "Block of words (already defined in local context)"
 ][
 	foreach word words [repend lib [word get word]]
 ]
 
-assert-utf8: function [
+assert-utf8: func-boot [
 	"If binary data is UTF-8, returns it, else throws an error."
 	data [binary!]
+	/local tmp
 ][
 	unless find [0 8] tmp: utf? data [ ; Not UTF-8
 		cause-error 'script 'no-decode ajoin ["UTF-" abs tmp]

--- a/src/mezz/sys-codec.r
+++ b/src/mezz/sys-codec.r
@@ -17,10 +17,11 @@ REBOL [
 	}
 ]
 
-decode: function [
+decode: func-boot [
  	{Decodes a series of bytes into the related datatype (e.g. image!).}
 	type [word!] {Media type (jpeg, png, etc.)}
 	data [binary!] {The data to decode}
+	/local cod
 ][
 	unless all [
 		cod: select system/codecs type
@@ -31,11 +32,12 @@ decode: function [
 	data
 ]
 
-encode: function [
+encode: func-boot [
 	{Encodes a datatype (e.g. image!) into a series of bytes.}
 	type [word!] {Media type (jpeg, png, etc.)}
 	data [image! binary! string!] {The data to encode}
 	/options opts [block!] {Special encoding options}
+	/local cod
 ][
 	unless all [
 		cod: select system/codecs type
@@ -46,7 +48,7 @@ encode: function [
 	data
 ]
 
-encoding?: function [
+encoding?: func-boot [
 	"Returns the media codec name for given binary data. (identify)"
 	data [binary!]
 ][

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -17,7 +17,7 @@ REBOL [
 	}
 ]
 
-start: func [
+start: func-boot [
 	"INIT: Completes the boot sequence. Loads extras, handles args, security, scripts."
 	/local file tmp script-path script-args code
 ] bind [ ; context is: system/options


### PR DESCRIPTION
The Mezzanine code (mostly) used a non-copying variant of FUNC, [simply defined](https://github.com/rebol/rebol/blob/4c32cc73b4641f8f6831b3ac549b5f5084c9e159/src/mezz/base-funcs.r#L19) as this:

```
func: make function! [[
    ; !!! This is a special minimal FUNC for more efficient boot. Gets replaced later in boot.
    {Non-copying function constructor (optimized for boot).}
    spec [block!] {Help string (opt) followed by arg words (and opt type and string)}
    body [block!] {The body block of the function}
][
    make function! reduce [spec body]
]]
```

Not copying creates a lot of potential for problems.  But a simple example shows why we don't define FUNC this way for the average user:

```
body: [
    value: {}
    append value {text}
    return value
]

x: func-boot [] body
insert body [print "Entering y function"]
y: func-boot [] body

x
y
```

Since the func-boot generator does not copy the body, this would mean the body winds up shared by both functions.  So calling x prints "Entering y function" also, and they share the same `value` string:

```
Entering y function
text
Entering y function
texttext
```

However, not copying saves on time and memory.  As long as you're not passing the same body to multiple functions, it should be able to work.

When the mezzanine was done with its loading, it would switch over to an implementation of FUNC that deep copied... [saving the old version into FUNCO](https://github.com/rebol/rebol/blob/08eb7e84cdadf450727501bb8ec02fad45696959/src/mezz/mezz-tail.r#L14)

There are a few problems with the way things were done:
- It was not easy to know by looking at code which variant of FUNC was in effect.  This made the usage of some mezzanines from within the mezzanine dangerous (such as COLLECT).  They would only be safe to use at the point where the changeover to a copying FUNC happened.
- Not all mezzanines followed the convention, and there were FUNCTION instances being used in various places... even ones with no set-words in them.  Given that it is hand-maintained system code, the time to scan the bodies for locals is probably not well spent.  _(There are also "word not bound to a context" errors to help catch any missed LOCALs.)_
- Most users would not be able to use FUNCO safely so exporting it is probably a bad idea.

So instead of changing the definition of FUNC in midstream, it seems much better to be explicit about which one the code is using.  FUNC-BOOT seemed like a more informative name than FUNCO.

FUNC is defined up front to give it an "early slot" (still not sure why that matters).  However it gives an error message if you use it too early, and returns #[unset!]

I changed it to not define FUNCTION until `%mezz-func.r`, which is currently the last thing that runs before `%mezz-tail.r`.  Any mezzanine functions that need to invoke FUNCTION at boot time would have to thus be after `%mezz-func.r`.  I turned all the existing FUNCTION instances prior to that into FUNC-BOOT with appropriate LOCALs.  Extra eyeballs to see what I might have missed are helpful; though I've done enough to keep the test suite from complaining.

The copying FUNC is also given its real definition in `%mezz-func.r`.

In `%mezz-tail.r`, the FUNC-BOOT is defined to produce an error message when invoked.  This prevents its use by users...while still giving a meaningful message for any code taken out of the mezzanine that is not adapted to use FUNC instead of FUNC-BOOT.

To help catch the kind of problematic cases that would mean you can't use FUNC-BOOT (e.g. modifying bodies) I did a PROTECT/DEEP on the spec and body passed in.  Outside of needing a couple of COPY operations on help strings that were trimmed in place (which probably should have only been done once anyway), it didn't need much changing.

Now that the FUNC-BOOT calls can be seen explicitly at the sites where they are used, it should be possible to review them for any cases where non-copying semantics would be bad.  And if you try to use something like COLLECT before the real FUNC is defined you'll get a runtime error.  This brings all that out into the open instead of having to keep track of it in one's head _(...if someone editing the code even realized it was going on in the first place!!)_
