### PR TITLE
Build CLI binaries for Android

### DIFF
--- a/src/boot/platforms.r
+++ b/src/boot/platforms.r
@@ -17,7 +17,7 @@ REBOL [
 Amiga		[1 m68k20+ 2 m68k 3 ppc]
 Macintosh	[1 mac-ppc 2 mac-m68k 3 mac-misc 4 osx-ppc 5 osx-x86]
 Windows		[1 win32-x86 2 dec-alpha]
-Linux		[1 libc5-x86 2 libc6-2-3-x86 3 libc6-2-5-x86 4 libc6-2-11-x86 10 libc6-ppc 20 libc6-arm 30 libc6-mips]
+Linux		[1 libc5-x86 2 libc6-2-3-x86 3 libc6-2-5-x86 4 libc6-2-11-x86 10 libc6-ppc 20 libc6-arm 21 bionic-arm 30 libc6-mips]
 Haiku		[75 x86-32]
 BSDi		[1 x86]
 FreeBSD		[1 x86 2 elf-x86]

--- a/src/os/posix/dev-file.c
+++ b/src/os/posix/dev-file.c
@@ -53,6 +53,14 @@
 #define O_BINARY 0
 #endif
 
+/*** Android don't have S_IREAD and S_IWRITE ***/
+#ifndef S_IREAD
+#define S_IREAD S_IRUSR
+#endif
+#ifndef S_IWRITE
+#define S_IWRITE S_IWUSR
+#endif
+
 // NOTE: the code below assumes a file id will never by zero. This should
 // be safe. In posix, zero is stdin, which is handled by dev-stdio.c.
 

--- a/src/os/posix/dev-file.c
+++ b/src/os/posix/dev-file.c
@@ -53,7 +53,7 @@
 #define O_BINARY 0
 #endif
 
-/*** Android don't have S_IREAD and S_IWRITE ***/
+// The BSD legacy names S_IREAD/S_IWRITE are not defined on e.g. Android.
 #ifndef S_IREAD
 #define S_IREAD S_IRUSR
 #endif

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -29,6 +29,7 @@ systems: [
 	[0.4.04 "linux"      posix  [+O2 HID LDL ST1 M32 -LM]]	; libc 2.11
 	[0.4.10 "linux_ppc"  posix  [+O1 HID LDL ST1 -LM]]
 	[0.4.20 "linux_arm"  posix  [+O2 HID LDL ST1 -LM]]
+	[0.4.21 "linux_arm"  posix  [+O2 HID LDL ST1 -LM PIE]]  ; bionic (Android)
 	[0.4.30 "linux_mips" posix  [+O2 HID LDL ST1 -LM]]  ; glibc does not need C++
 	[0.5.75 "haiku"      posix  [+O2 ST1 NWK]]
 	[0.7.02 "freebsd"    posix  [+O1 C++ ST1 -LM]]
@@ -45,6 +46,7 @@ compile-flags: [
 	NPS: "-Wno-pointer-sign"      ; OSX fix
 	NSP: "-fno-stack-protector"   ; avoid insert of functions names
 	PIC: "-fPIC"                  ; position independent (used for libs)
+	PIE: "-fPIE"                  ; position independent (executables)
 	DYN: "-dynamic"               ; optimize for dll??
 	NCM: "-fno-common"            ; lib cannot have common vars
 	PAK: "-fpack-struct"          ; pack structures


### PR DESCRIPTION
This is a slightly modified version (and replacement) of @giuliolunati's #190 adding a `4.21` build target for "Android CLI" binaries.

**Why is that a "Linux" number?** Underneath, Android is a Linux with a different libc (called Bionic). As such, the CLI binary is much more Linux-like and distinct from a "proper" Android GUI application (.apk; for which we'd have the 13.x platform numbers reserved).

With these changes, @giuliolunati, @BrianHawley, and myself independently managed to build natively on Android directly and/or cross-compile for Android with the NDK.

**Cross-compilation: Build steps I used with the [Android NDK r9c](https://developer.android.com/tools/sdk/ndk/index.html)**

This needs a pre-built `r3-make` binary already in the `make/` folder, for the `make prep` step.
1. `export NDKROOT=/opt/android-ndk` - a custom environment variable I set to point to my NDK install
2. `export TOOLCHAIN=$NDKROOT/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64` - a custom environment variable to point to the NDK toolchain I want to use
3. `make make OS_ID=0.4.21`
4. `make prep`
5. Build R3 with custom TOOLS, INCL, and CC settings:

```
make r3 \
  TOOLS=$TOOLCHAIN/bin/arm-linux-androideabi- \
  INCL=$TOOLCHAIN/include/ \
  CC="$TOOLCHAIN/bin/arm-linux-androideabi-gcc --sysroot=$NDKROOT/platforms/android-9/arch-arm/"
```

**Native on-target compilation: Build steps I used on an Android device with [TerminalIDE](https://play.google.com/store/apps/details?id=com.spartacusrex.spartacuside)**

This needs a pre-built `r3-make` Android CLI binary already in the `make/` folder, for the `make prep` step. That can initially via obtained by cross-compilation.
1. `make make OS_ID=0.4.21`
2. `make prep`
3. `make r3 CC=terminal-gcc TOOLS=arm-eabi-`

Thanks to @giuliolunati and @BrianHawley for their work on getting this built!
