### PR TITLE
DO-CODEC related fixes

### DIFF
--- a/src/core/n-system.c
+++ b/src/core/n-system.c
@@ -443,19 +443,21 @@ err:
 	case CODI_CHECK:
 		return R_TRUE;
 
-	case CODI_BINARY:
-	case CODI_TEXT:
+	case CODI_BINARY: //used on encode
+	case CODI_TEXT: //used on decode
 		ser = Make_Binary(codi.len);
 		ser->tail = codi.len;
 		memcpy(BIN_HEAD(ser), codi.data, codi.len);
 		Set_Binary(D_RET, ser);
 		if (result != CODI_BINARY) VAL_SET(D_RET, REB_STRING);
-		
-		// See notice in reb-codec.h on reb_codec_image 
-		Free_Mem(codi.data, codi.len);
+
+		//don't free the text binary input buffer during decode (it's the 3rd arg value in fact)
+		if (result == CODI_BINARY)
+			// See notice in reb-codec.h on reb_codec_image 
+			Free_Mem(codi.data, codi.len);
 		break;
 
-	case CODI_IMAGE:
+	case CODI_IMAGE: //used on decode
 		ser = Make_Image(codi.w, codi.h, TRUE); // Puts it into RETURN stack position
 		memcpy(IMG_DATA(ser), codi.bits, codi.w * codi.h * 4);
 		SET_IMAGE(D_RET, ser);

--- a/src/core/u-zlib.c
+++ b/src/core/u-zlib.c
@@ -287,6 +287,8 @@ int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
     }
     if (strm->zfree == Z_NULL) strm->zfree = zcfree;
 
+	if (!strm->checksum) strm->checksum = adler32;
+	
     if (level == Z_DEFAULT_COMPRESSION) level = 6;
 /* #ifdef FASTEST */
 /*     level = 1; */

--- a/src/include/reb-codec.h
+++ b/src/include/reb-codec.h
@@ -35,10 +35,15 @@
 // of size (->w * ->h * 4).  This will be freed by the
 // REBNATIVE(do_codec) in n-system.c
 //
-// If your codec routine returns CODI_BINARY or CODI_TEXT, it is
+// If your codec routine returns CODI_BINARY, it is
 // expected that the ->data field contains a block of memory
 // allocated with Make_Mem of size ->len.  This will be freed by
 // the REBNATIVE(do_codec) in n-system.c
+//
+// If your codec routine returns CODI_TEXT, it is
+// expected that the ->data field is 3rd input binary! argument in
+// the REBNATIVE(do_codec) in n-system.c
+// so the deallocation is left to GC
 //
 typedef struct reb_codec_image {
 	int action;


### PR DESCRIPTION
This pull request fixes the regression crash introduced by https://github.com/rebol/rebol/pull/156 which caused TEXT type decoding operation non-functional.
It also fixes the crash when encoding image using PNG codec ([CC#2040](http://issue.cc/r3/2040)).

Here is a link to Gist that includes all basic DO-CODEC tests for possible reveal of regression:
https://gist.github.com/cyphre/9254624
