### PR TITLE
Use FUNC instead of FUNCTION to speedup startup

### DIFF
--- a/src/mezz/base-files.r
+++ b/src/mezz/base-files.r
@@ -172,9 +172,10 @@ split-path: func [
 	reduce [dir pos]
 ]
 
-intern: function [
+intern: func [
 	"Imports (internalize) words and their values from the lib into the user context."
 	data [block! any-word!] "Word or block of words to be added (deeply)"
+	/local index usr
 ][
 	index: 1 + length? usr: system/contexts/user ; optimization
 	data: bind/new :data usr   ; Extend the user context with new words
@@ -182,12 +183,13 @@ intern: function [
 	:data
 ]
 
-load: function [
+load: func [
 	{Simple load of a file, URL, or string/binary - minimal boot version.}
 	source [file! url! string! binary!]
 	/header  {Includes REBOL header object if present}
 	/all     {Load all values, including header (as block)}
 	;/unbound {Do not bind the block}
+	/local data hdr?
 ][
 	if string? data: case [
 		file? source [read source]

--- a/src/mezz/mezz-debug.r
+++ b/src/mezz/mezz-debug.r
@@ -11,9 +11,10 @@ REBOL [
 	}
 ]
 
-dt: delta-time: function [
+dt: delta-time: func [
 	{Delta-time - returns the time it takes to evaluate the block.}
 	block [block!]
+	/local start
 ][
 	start: stats/timer
 	do block
@@ -37,10 +38,11 @@ dp: delta-profile: func [
 	start
 ]
 
-speed?: function [
+speed?: func [
 	"Returns approximate speed benchmarks [eval cpu memory file-io]."
 	/no-io "Skip the I/O test"
 	/times "Show time for each test"
+	/local result x calc tmp secs
 ][
 	result: copy []
 	foreach block [

--- a/src/mezz/mezz-files.r
+++ b/src/mezz/mezz-files.r
@@ -62,9 +62,10 @@ clean-path: func [
 	reverse out
 ]
 
-input: function [
+input: func [
 	{Inputs a string from the console. New-line character is removed.}
 ;	/hide "Mask input with a * character"
+	/local line
 ][
 	if any [
 		not port? system/ports/input

--- a/src/mezz/mezz-help.r
+++ b/src/mezz/mezz-help.r
@@ -12,10 +12,11 @@ REBOL [
 ]
 
 ; MOVE THIS INTERNAL FUNC:
-dump-obj: function [
+dump-obj: func [
 	"Returns a block of information about an object or port."
 	obj [object! port!]
 	/match "Include only those that match a string or datatype" pat
+	/local clip-str form-val form-pad out wild type str
 ][
 	clip-str: func [str] [
 		; Keep string to one line.
@@ -95,7 +96,7 @@ dump-obj: function [
 	/local value args item type-name types tmp print-args
 ][
 	if unset? get/any 'word [
-		print trim/auto {
+		print trim/auto copy {
 			Use HELP or ? to see built-in info:
 
 				help insert
@@ -325,7 +326,7 @@ about: func [
 usage: func [
 	"Prints command-line arguments."
 ][
-	print trim/auto {
+	print trim/auto copy {
 	Command line usage:
 
 		REBOL |options| |script| |arguments|
@@ -422,8 +423,9 @@ say-browser: does [
 	print "Opening web browser..."
 ]
 
-upgrade: function [
+upgrade: func [
 	"Check for newer versions (update REBOL)."
+	/local err
 ][
 	print "Fetching upgrade check ..."
 	if error? err: try [do http://www.rebol.com/r3/upgrade.r none][
@@ -432,8 +434,9 @@ upgrade: function [
 	exit
 ]
 
-chat: function [
+chat: func [
 	"Open REBOL DevBase forum/BBS."
+	/local err
 ][
 	print "Fetching chat..."
 	if error? err: try [do http://www.rebol.com/r3/chat.r none][
@@ -489,8 +492,9 @@ why?: func [
 	exit
 ]
 
-demo: function [
+demo: func [
 	"Run R3 demo."
+	/local err
 ][
 	print "Fetching demo..."
 	if error? err: try [do http://www.rebol.com/r3/demo.r none][
@@ -499,12 +503,13 @@ demo: function [
 	exit
 ]
 
-load-gui: function [
+load-gui: func [
 	"Download current GUI module from web. (Temporary)"
+	/local data
 ][
 	print "Fetching GUI..."
 	either error? data: try [load http://www.rebol.com/r3/gui.r][
-		either data/id = 'protocol [print "Cannot load GUI from web."][do err]
+		either data/id = 'protocol [print "Cannot load GUI from web."][do data]
 	][
 		do data
 	]

--- a/src/mezz/mezz-save.r
+++ b/src/mezz/mezz-save.r
@@ -15,9 +15,10 @@ REBOL [
 	}
 ]
 
-mold64: function [
+mold64: func [
 	"Temporary function to mold binary base 64." ; fix the need for this! -CS
 	data
+	/local base
 ][
 	base: system/options/binary-base
 	system/options/binary-base: 64
@@ -26,7 +27,7 @@ mold64: function [
 	data
 ]
 
-save: function [
+save: func [
 	{Saves a value, block, or other data to a file, URL, binary, or string.}
 	where [file! url! binary! string! none!] {Where to save (suffix determines encoding)}
 	value {Value(s) to save}
@@ -36,6 +37,7 @@ save: function [
 	/length {Save the length of the script content in the header}
 	/compress {Save in a compressed format or not}
 	method [logic! word!] "true = compressed, false = not, 'script = encoded string"
+	/local type data tmp
 ][
 	;-- Special datatypes use codecs directly (e.g. PNG image file):
 	if lib/all [

--- a/src/mezz/mezz-series.r
+++ b/src/mezz/mezz-series.r
@@ -360,11 +360,12 @@ collect: func [
 	either into [output] [head output]
 ]
 
-format: function [
+format: func [
 	"Format a string according to the format dialect."
 	rules {A block in the format dialect. E.g. [10 -10 #"-" 4]}
 	values
 	/pad p
+	/local val out
 ][
 	p: any [p #" "]
 	unless block? :rules [rules: reduce [:rules]]

--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -203,9 +203,10 @@ export: func [
 	foreach word words [repend lib [word get word]]
 ]
 
-assert-utf8: function [
+assert-utf8: func [
 	"If binary data is UTF-8, returns it, else throws an error."
 	data [binary!]
+	/local tmp
 ][
 	unless find [0 8] tmp: utf? data [ ; Not UTF-8
 		cause-error 'script 'no-decode ajoin ["UTF-" abs tmp]

--- a/src/mezz/sys-codec.r
+++ b/src/mezz/sys-codec.r
@@ -17,10 +17,11 @@ REBOL [
 	}
 ]
 
-decode: function [
+decode: func [
  	{Decodes a series of bytes into the related datatype (e.g. image!).}
 	type [word!] {Media type (jpeg, png, etc.)}
 	data [binary!] {The data to decode}
+	/local cod
 ][
 	unless all [
 		cod: select system/codecs type
@@ -31,11 +32,12 @@ decode: function [
 	data
 ]
 
-encode: function [
+encode: func [
 	{Encodes a datatype (e.g. image!) into a series of bytes.}
 	type [word!] {Media type (jpeg, png, etc.)}
 	data [image! binary! string!] {The data to encode}
 	/options opts [block!] {Special encoding options}
+	/local cod
 ][
 	unless all [
 		cod: select system/codecs type
@@ -46,7 +48,7 @@ encode: function [
 	data
 ]
 
-encoding?: function [
+encoding?: func [
 	"Returns the media codec name for given binary data. (identify)"
 	data [binary!]
 ][


### PR DESCRIPTION
Translated uses of FUNCTION to FUNC, to lower overhead during Rebol
startup code. Guess FUNCTION wasn't pretranslated by the bootstrap.

Also, fixed a few literal series modifications that could be copies.
