### PR TITLE
Restructure platforms list for easier extensibility & cleanup whitespace and libstdc++ linking

### DIFF
--- a/src/boot/platforms.r
+++ b/src/boot/platforms.r
@@ -14,18 +14,82 @@ REBOL [
 	}
 ]
 
-Amiga		[1 m68k20+ 2 m68k 3 ppc]
-Macintosh	[1 mac-ppc 2 mac-m68k 3 mac-misc 4 osx-ppc 5 osx-x86]
-Windows		[1 win32-x86 2 dec-alpha]
-Linux		[1 libc5-x86 2 libc6-2-3-x86 3 libc6-2-5-x86 4 libc6-2-11-x86 10 libc6-ppc 20 libc6-arm 21 bionic-arm 30 libc6-mips]
-Haiku		[75 x86-32]
-BSDi		[1 x86]
-FreeBSD		[1 x86 2 elf-x86]
-NetBSD		[1 x86 2 ppc 3 m68k 4 dec-alpha 5 sparc]
-OpenBSD		[1 x86 2 ppc 3 m68k 4 elf-x86 5 sparc]
-Sun			[1 sparc]
-SGI			[]
-HP			[]
-Android		[1 arm]
-free-slot	[]
-WindowsCE	[1 sh3 2 mips 5 arm 6 sh4]
+1 Amiga [
+	1 m68k20+
+	2 m68k
+	3 ppc
+]
+
+2 Macintosh [
+	1 mac-ppc
+	2 mac-m68k
+	3 mac-misc
+	4 osx-ppc
+	5 osx-x86
+]
+
+3 Windows [
+	1 win32-x86
+	2 dec-alpha
+]
+
+4 Linux [
+	1 libc5-x86
+	2 libc6-2-3-x86
+	3 libc6-2-5-x86
+	4 libc6-2-11-x86
+	10 libc6-ppc
+	20 libc6-arm
+	21 bionic-arm
+	30 libc6-mips
+]
+
+5 Haiku [
+	75 x86-32
+]
+
+6 BSDi [
+	1 x86
+]
+
+7 FreeBSD [
+	1 x86
+	2 elf-x86
+]
+
+8 NetBSD [
+	1 x86
+	2 ppc
+	3 m68k
+	4 dec-alpha
+	5 sparc
+]
+
+9 OpenBSD [
+	1 x86
+	2 ppc
+	3 m68k
+	4 elf-x86
+	5 sparc
+]
+
+10 Sun [
+	1 sparc
+]
+
+11 SGI []
+
+12 HP []
+
+13 Android [
+	1 arm
+]
+
+14 free-slot []
+
+15 WindowsCE [
+	1 sh3
+	2 mips
+	5 arm
+	6 sh4
+]

--- a/src/tools/make-boot.r
+++ b/src/tools/make-boot.r
@@ -790,8 +790,8 @@ change at-value product to lit-word! product
 plats: load %platforms.r
 
 change/only at-value platform reduce [
-	any [pick plats version/4 * 2 - 1 "Unknown"]
-	any [select pick plats version/4 * 2 version/5 ""]
+	any [select plats version/4 "Unknown"]
+	any [select third any [find/skip plats version/4 3 []] version/5 ""]
 ]
 
 ob: context boot-sysobj

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -30,10 +30,10 @@ systems: [
 	[0.4.10		"linux_ppc"		posix		[+O1 HID LDL ST1 -LM]]
 	[0.4.20		"linux_arm"		posix		[+O2 HID LDL ST1 -LM]]
 	[0.4.21		"linux_arm"		posix		[+O2 HID LDL ST1 -LM PIE]]	; bionic (Android)
-	[0.4.30		"linux_mips"	posix		[+O2 HID LDL ST1 -LM]]		; glibc does not need C++
+	[0.4.30		"linux_mips"	posix		[+O2 HID LDL ST1 -LM]]
 	[0.5.75		"haiku"			posix		[+O2 ST1 NWK]]
-	[0.7.02		"freebsd"		posix		[+O1 C++ ST1 -LM]]
-	[0.9.04		"openbsd"		posix		[+O1 C++ ST1 -LM]]
+	[0.7.02		"freebsd"		posix		[+O1 ST1 -LM]]
+	[0.9.04		"openbsd"		posix		[+O1 ST1 -LM]]
 	[0.13.01	"android_arm"	android		[HID F64 LDL LLOG -LM CST]]
 ]
 
@@ -59,7 +59,6 @@ compile-flags: [
 linker-flags: [
 	MAP:	"-Wl,-M"					; output a map
 	STA:	"--strip-all"
-	C++:	"-lstdc++"					; link with stdc++
 	LDL:	"-ldl"						; link with dynamic lib lib
 	LLOG:	"-llog"						; on Android, link with liblog.so
 	ARC:	"-arch i386"				; x86 32 bit architecture (OSX)

--- a/src/tools/systems.r
+++ b/src/tools/systems.r
@@ -19,69 +19,69 @@ REBOL [
 ]
 
 systems: [
-	[plat  os-name   os-base  build-flags]
-	[0.1.03 "amiga"      posix  [HID NPS +SC CMT COP -SP -LM]]
-	[0.2.04 "osx"        posix  [+OS NCM -LM]]			; no shared lib possible
-	[0.2.05 "osxi"       posix  [ARC +O1 NPS PIC NCM HID STX -LM]]
-	[0.3.01 "win32"      win32  [+O2 UNI W32 CON S4M EXE DIR -LM]]
-	[0.4.02 "linux"      posix  [+O2 LDL ST1 -LM]]		; libc 2.3
-	[0.4.03 "linux"      posix  [+O2 HID LDL ST1 -LM]]	; libc 2.5
-	[0.4.04 "linux"      posix  [+O2 HID LDL ST1 M32 -LM]]	; libc 2.11
-	[0.4.10 "linux_ppc"  posix  [+O1 HID LDL ST1 -LM]]
-	[0.4.20 "linux_arm"  posix  [+O2 HID LDL ST1 -LM]]
-	[0.4.21 "linux_arm"  posix  [+O2 HID LDL ST1 -LM PIE]]  ; bionic (Android)
-	[0.4.30 "linux_mips" posix  [+O2 HID LDL ST1 -LM]]  ; glibc does not need C++
-	[0.5.75 "haiku"      posix  [+O2 ST1 NWK]]
-	[0.7.02 "freebsd"    posix  [+O1 C++ ST1 -LM]]
-	[0.9.04 "openbsd"    posix  [+O1 C++ ST1 -LM]]
-	[0.13.01 "android_arm"  android  [HID F64 LDL LLOG -LM CST]]
+	[plat		os-name			os-base		build-flags]
+	[0.1.03		"amiga"			posix		[HID NPS +SC CMT COP -SP -LM]]
+	[0.2.04		"osx"			posix		[+OS NCM -LM]]				; no shared lib possible
+	[0.2.05		"osxi"			posix		[ARC +O1 NPS PIC NCM HID STX -LM]]
+	[0.3.01		"win32"			win32		[+O2 UNI W32 CON S4M EXE DIR -LM]]
+	[0.4.02		"linux"			posix		[+O2 LDL ST1 -LM]]			; libc 2.3
+	[0.4.03		"linux"			posix		[+O2 HID LDL ST1 -LM]]		; libc 2.5
+	[0.4.04		"linux"			posix		[+O2 HID LDL ST1 M32 -LM]]	; libc 2.11
+	[0.4.10		"linux_ppc"		posix		[+O1 HID LDL ST1 -LM]]
+	[0.4.20		"linux_arm"		posix		[+O2 HID LDL ST1 -LM]]
+	[0.4.21		"linux_arm"		posix		[+O2 HID LDL ST1 -LM PIE]]	; bionic (Android)
+	[0.4.30		"linux_mips"	posix		[+O2 HID LDL ST1 -LM]]		; glibc does not need C++
+	[0.5.75		"haiku"			posix		[+O2 ST1 NWK]]
+	[0.7.02		"freebsd"		posix		[+O1 C++ ST1 -LM]]
+	[0.9.04		"openbsd"		posix		[+O1 C++ ST1 -LM]]
+	[0.13.01	"android_arm"	android		[HID F64 LDL LLOG -LM CST]]
 ]
 
 compile-flags: [
-	+OS: "-Os"                    ; size optimize
-	+O1: "-O1"                    ; full optimize
-	+O2: "-O2"                    ; full optimize
-	UNI: "-DUNICODE"              ; win32 wants it
-	CST: "-DCUSTOM_STARTUP"		  ; include custom startup script at host boot
-	HID: "-fvisibility=hidden"    ; all syms are hidden
-	F64: "-D_FILE_OFFSET_BITS=64" ; allow larger files
-	NPS: "-Wno-pointer-sign"      ; OSX fix
-	NSP: "-fno-stack-protector"   ; avoid insert of functions names
-	PIC: "-fPIC"                  ; position independent (used for libs)
-	PIE: "-fPIE"                  ; position independent (executables)
-	DYN: "-dynamic"               ; optimize for dll??
-	NCM: "-fno-common"            ; lib cannot have common vars
-	PAK: "-fpack-struct"          ; pack structures
-	ARC: "-arch i386"             ; x86 32 bit architecture (OSX)
-	M32: "-m32"                   ; use 32-bit memory model
+	+OS:	"-Os"						; size optimize
+	+O1:	"-O1"						; full optimize
+	+O2:	"-O2"						; full optimize
+	UNI:	"-DUNICODE"					; win32 wants it
+	CST:	"-DCUSTOM_STARTUP"			; include custom startup script at host boot
+	HID:	"-fvisibility=hidden"		; all syms are hidden
+	F64:	"-D_FILE_OFFSET_BITS=64"	; allow larger files
+	NPS:	"-Wno-pointer-sign"			; OSX fix
+	NSP:	"-fno-stack-protector"		; avoid insert of functions names
+	PIC:	"-fPIC"						; position independent (used for libs)
+	PIE:	"-fPIE"						; position independent (executables)
+	DYN:	"-dynamic"					; optimize for dll??
+	NCM:	"-fno-common"				; lib cannot have common vars
+	PAK:	"-fpack-struct"				; pack structures
+	ARC:	"-arch i386"				; x86 32 bit architecture (OSX)
+	M32:	"-m32"						; use 32-bit memory model
 ]
 
 linker-flags: [
-	MAP: "-Wl,-M"  ; output a map
-	STA: "--strip-all"
-	C++: "-lstdc++" ; link with stdc++
-	LDL: "-ldl"     ; link with dynamic lib lib
-	LLOG: "-llog"	; on Android, link with liblog.so
-	ARC: "-arch i386" ; x86 32 bit architecture (OSX)
-	M32: "-m32"       ; use 32-bit memory model (Linux x64)
-	W32: "-lwsock32 -lcomdlg32"
-	WIN: "-mwindows" ; build as Windows GUI binary
-	CON: "-mconsole" ; build as Windows Console binary
-	S4M: "-Wl,--stack=4194300"
-	-LM: "-lm" ; HaikuOS has math in libroot, for instance
-	NWK: "-lnetwork" ; Needed by HaikuOS
+	MAP:	"-Wl,-M"					; output a map
+	STA:	"--strip-all"
+	C++:	"-lstdc++"					; link with stdc++
+	LDL:	"-ldl"						; link with dynamic lib lib
+	LLOG:	"-llog"						; on Android, link with liblog.so
+	ARC:	"-arch i386"				; x86 32 bit architecture (OSX)
+	M32:	"-m32"						; use 32-bit memory model (Linux x64)
+	W32:	"-lwsock32 -lcomdlg32"
+	WIN:	"-mwindows"					; build as Windows GUI binary
+	CON:	"-mconsole"					; build as Windows Console binary
+	S4M:	"-Wl,--stack=4194300"
+	-LM:	"-lm"						; HaikuOS has math in libroot, for instance
+	NWK:	"-lnetwork"					; Needed by HaikuOS
 ]
 
 other-flags: [
-	+SC: ""		; has smart console
-	-SP: ""		; non standard paths
-	COP: ""		; use COPY as cp program
-	DIR: ""		; use DIR as ls program
-	ST1: "-s"	; strip flags...
-	STX: "-x"
-	ST2: "-S -x -X"
-	CMT: "-R.comment"
-	EXE: ""		; use %.exe as binary file suffix
+	+SC:	""							; has smart console
+	-SP:	""							; non standard paths
+	COP:	""							; use COPY as cp program
+	DIR:	""							; use DIR as ls program
+	ST1:	"-s"						; strip flags...
+	STX:	"-x"
+	ST2:	"-S -x -X"
+	CMT:	"-R.comment"
+	EXE:	""							; use %.exe as binary file suffix
 ]
 
 config-system: func [


### PR DESCRIPTION
Primarily, this is a minor restructuring of `src/boot/platforms.r` to make it easier to maintain (and merge).

On top of that, the platform build specification is consistently reformatted. Previously, while always using hard tabs for indentation, a complete mixture of tabs and spaces was used for alignment. This is cleaned up to always use hardtabs both for indentation and alignment.

Finally, the unneccesary linking against libstdc++ for FreeBSD and OpenBSD is dropped. Test builds on both systems succeeded with that linkage, and the resulting binaries work just fine.
