### PR TITLE
Cause an error in PARSE for invalid args to TO (and THRU)

### DIFF
--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -532,6 +532,8 @@ bad_target:
 				i = Find_Str_Bitset(series, 0, index, series->tail, 1, VAL_BITSET(item), HAS_CASE(parse));
 				if (i != NOT_FOUND && is_thru) i++;
 			}
+			else
+				Trap1(RE_PARSE_RULE, item - 1);
 		}
 	}
 


### PR DESCRIPTION
Previously, PARSE over string input would silently ignore invalid arguments to TO (and THRU). With this fix, invalid args to TO and THRU correctly cause an error:

```
>> parse "foo" [to 1.2]
** Script error: PARSE - invalid rule or usage of rule: to
** Where: parse
** Near: parse "foo" [to 1.2]
```

The problem was identified via static code analysis with Cppcheck.
