### PR TITLE
TO-VALUE function

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -596,6 +596,11 @@ value?: native [
 	value
 ]
 
+to-value: native [
+	{Returns the value if it is a value, NONE if unset.}
+	value [any-type!]
+]
+
 ;-- IO Natives - nat_io.c
 
 print: native [

--- a/src/core/n-data.c
+++ b/src/core/n-data.c
@@ -644,6 +644,16 @@ static int Check_Char_Range(REBVAL *val, REBINT limit)
 }
 
 
+/***********************************************************************
+**
+*/	REBNATIVE(to_value)
+/*
+***********************************************************************/
+{
+	return (IS_UNSET(D_ARG(1)) ? R_NONE : R_ARG1);
+}
+
+
 //** SERIES ************************************************************
 
 static int Do_Ordinal(REBVAL *ds, REBINT n)


### PR DESCRIPTION
This fills a hole in the basic evaluation model: converting non-values to values. This is how you turn an unset value that doesn't have to be considered erroneous into a nice safe none; all else passed through. Filters out the unset values from the data flow.

See http://issue.cc/r3/2003 for details.
