### PR TITLE
Fix PARSE position capture combined with SET or COPY

### DIFF
--- a/src/core/u-parse.c
+++ b/src/core/u-parse.c
@@ -794,11 +794,8 @@ bad_target:
 
 			} else { // It's not a PARSE command, get or set it:
 			
-				// word: - if not the target of a COPY or SET operation, this will
-				// default to setting a variable to the series at current index
-				if (IS_SET_WORD(item) &&
-					!(GET_FLAG(flags, PF_SET_OR_COPY) || GET_FLAG(flags, PF_COPY)))
-				{
+				// word: - set a variable to the series at current index
+				if (IS_SET_WORD(item)) {
 					Set_Var_Series(item, parse->type, series, index);
 					continue;
 				}


### PR DESCRIPTION
The recent extension to allow set-word! usage in SET and COPY rules introduced a regression: set-word!s (for position capture) in the rule immediately following a `SET word` or `COPY word` rule cause a match failure. For example:

```
>> parse [x] [set val pos: word!]
== false  ;; Expected: true
```

This commit fixes this issue ([CureCode issue 2130](http://issue.cc/r3/2130)), a regression caused by 8db79a9 (PR #165).

Corresponding tests have been added to the test suite (rebolsource/rebol-test@fe8df53).
