### PR TITLE
Add support for APPLY :DO [:function]

### DIFF
--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -293,6 +293,7 @@ enum {
 ***********************************************************************/
 {
 	Apply_Block(D_ARG(1), D_ARG(2), !D_REF(3)); // stack volatile
+	VAL_CLR_OPT(DS_TOP, OPTS_REVAL);
 	return R_TOS;
 }
 


### PR DESCRIPTION
APPLY :DO [:function] handles the first argument block (the one to DO)
but doesn't handle the second (the one to the function). This change
will allow you to handle the second argument block with a chained
call to APPLY, or to not do the reval at all if you like.

See http://issue.cc/r3/2135 for details.
