### PR TITLE
Properly type check values for APPEND to file ports

### DIFF
--- a/src/core/p-file.c
+++ b/src/core/p-file.c
@@ -360,6 +360,8 @@ REBINT Mode_Syms[] = {
 		break;
 
 	case A_APPEND:
+		if (!(IS_BINARY(D_ARG(2)) || IS_STRING(D_ARG(2)) || IS_BLOCK(D_ARG(2))))
+			Trap1(RE_INVALID_ARG, D_ARG(2));
 		file->file.index = file->file.size;
 		SET_FLAG(file->modes, RFM_RESEEK);
 


### PR DESCRIPTION
Currently, `append` on a file port! is just a shortcut for `write/append`. However, `append` has a less restrictive type spec than `write/append`. `write` only accepts `[binary! string! block!]`, whereas `append` accepts any type.

Currently, calling `append` on a file port with a value not also supported by `write` has a high chance of crashing the interpreter. For example, consider [CureCode issue 1894](http://issue.cc/r3/1894):

```
>> p: open/new %pokus.txt
>> append p #"x"  ;; Crashes the interpreter.
```

This commit fixes the crash by adding additional type checks for `append` on file ports:

```
>> p: open/new %pokus.txt
>> append p #"x"
** Script error: invalid argument: #"x"
** Where: append
** Near: append p #"x"
```

This fixes [CureCode issue 1894](http://issue.cc/r3/1894).
