### PR TITLE
Fix a crash upon READ or WRITE failure on POSIX systems

### DIFF
--- a/src/os/posix/dev-file.c
+++ b/src/os/posix/dev-file.c
@@ -352,6 +352,8 @@ fail:
 /*
 ***********************************************************************/
 {
+	ssize_t num_bytes;
+
 	if (GET_FLAG(file->modes, RFM_DIR)) {
 		return Read_Directory(file, (REBREQ*)file->data);
 	}
@@ -367,11 +369,12 @@ fail:
 	}
 
 	// printf("read %d len %d\n", file->id, file->length);
-	file->actual = read(file->id, file->data, file->length);
-	if (file->actual < 0) {
+	num_bytes = read(file->id, file->data, file->length);
+	if (num_bytes < 0) {
 		file->error = -RFE_BAD_READ;
 		return DR_ERROR;
 	} else {
+		file->actual = num_bytes;
 		file->file.index += file->actual;
 	}
 
@@ -387,6 +390,8 @@ fail:
 **
 ***********************************************************************/
 {
+	ssize_t num_bytes;
+
 	if (!file->id) {
 		file->error = -RFE_NO_HANDLE;
 		return DR_ERROR;
@@ -406,11 +411,13 @@ fail:
 
 	if (file->length == 0) return DR_DONE;
 
-	file->actual = write(file->id, file->data, file->length);
-	if (file->actual < 0) {
+	num_bytes = write(file->id, file->data, file->length);
+	if (num_bytes < 0) {
 		if (errno == ENOSPC) file->error = -RFE_DISK_FULL;
 		else file->error = -RFE_BAD_WRITE;
 		return DR_ERROR;
+	} else {
+		file->actual = num_bytes;
 	}
 
 	return DR_DONE;


### PR DESCRIPTION
When read(3) or write(3) fail, they return -1. However, the `actual` field of `REBREQ` used to store this return value is unsigned. This on the one hand means, that `< 0` error checks will never fire. Further, `actual` is set to max value, which can cause errors further down the line, such as in the actual READ reactor, `Read_File_Port`, which assumes that `actual` is smaller than `len`.

This commit properly handles read/write errors indicated by -1.

This fixes the crash aspect of [CureCode issue #1675](http://issue.cc/r3/1675).
