### PR TITLE
Add PAIR! support for REPEAT

### DIFF
--- a/src/boot/natives.r
+++ b/src/boot/natives.r
@@ -150,9 +150,9 @@ find-script: native [
 for: native [
 	{Evaluate a block over a range of values. (See also: REPEAT)}
 	'word [word!] "Variable to hold current value"
-	start [series! number!] "Starting value"
-	end   [series! number!] "Ending value"
-	bump  [number!] "Amount to skip each time"
+	start [series! number! pair!] "Starting value"
+	end   [series! number! pair!] "Ending value"
+	bump  [number! pair!] "Amount to skip each time"
 	body  [block!] "Block to evaluate"
 ]
 
@@ -258,7 +258,7 @@ reduce: native [
 repeat: native [
 	{Evaluates a block a number of times or over a series.}
 	'word [word!] {Word to set each time}
-	value [number! series! none!] {Maximum number or series to traverse}
+	value [number! series! pair! none!] {Maximum number or series to traverse}
 	body [block!] {Block to evaluate each time}
 ]
 

--- a/src/core/n-loop.c
+++ b/src/core/n-loop.c
@@ -137,6 +137,31 @@
 
 /***********************************************************************
 **
+*/	static void Loop_Pair(REBVAL *var, REBSER* body, REBD32 xstart, REBD32 ystart, REBD32 xend, REBD32 yend, REBD32 xincr, REBD32 yincr)
+/*
+***********************************************************************/
+{
+	REBD32 xi;
+	REBD32 yi;
+	REBVAL *result;
+
+	VAL_SET(var, REB_PAIR);
+	for (yi = ystart; (yincr > 0.) ? yi <= yend : yi >= yend; yi += yincr) {
+		for (xi = xstart; (xincr > 0.) ? xi <= xend : xi >= xend; xi += xincr) {
+			VAL_PAIR_X(var) = xi;
+			VAL_PAIR_Y(var) = yi;
+			result = Do_Blk(body, 0);
+			if (THROWN(result) && Check_Error(result) >= 0) return;
+			if (!IS_PAIR(var)) Trap_Type(var);
+			xi = VAL_PAIR_X(var);
+			yi = VAL_PAIR_Y(var);
+		}
+	}
+}
+
+
+/***********************************************************************
+**
 */	static void Loop_Number(REBVAL *var, REBSER* body, REBVAL *start, REBVAL *end, REBVAL *incr)
 /*
 ***********************************************************************/
@@ -486,6 +511,12 @@ skip_hidden: ;
 		//if (ANY_SERIES(end) && VAL_SERIES(start) != VAL_SERIES(end)) Trap_Arg(end);
 		Loop_Series(var, body, start, ANY_SERIES(end) ? VAL_INDEX(end) : (Int32s(end, 1) - 1), Int32(incr));
 	}
+	else if (IS_PAIR(start) && IS_PAIR(end) && IS_PAIR(incr)) {
+		Loop_Pair(var, body,
+			VAL_PAIR_X(start), VAL_PAIR_Y(start),
+			VAL_PAIR_X(end), VAL_PAIR_Y(end),
+			VAL_PAIR_X(incr), VAL_PAIR_Y(incr));
+	}
 	else
 		Loop_Number(var, body, start, end, incr);
 
@@ -629,6 +660,9 @@ skip_hidden: ;
 	}
 	else if (IS_INTEGER(count)) {
 		Loop_Integer(var, body, 1, VAL_INT64(count), 1);
+	}
+	else if (IS_PAIR(count)) {
+		Loop_Pair(var, body, 1., 1., VAL_PAIR_X(count), VAL_PAIR_Y(count), 1., 1.);
 	}
 
 	return R_TOS1;


### PR DESCRIPTION
This change allows PAIR! values as value argument of REPEAT. This
enables convenient traversal over a 2D space:

```
>> repeat p 3x3 [print p]
1x1
2x1
3x1
1x2
2x2
3x2
1x3
2x3
3x3
```

Similar to REPEAT over decimals, REPEAT over pairs implies a start of
1.0x1.0 and a default bump of 1.0 for each component. The first pair
component ("X") is varied first, which is in line with pair!-based
indexing into image!s.

For the sake of completeness, PAIR! support is also enabled in the
legacy C-style FOR:

```
>> for p 10x10 15x20 5x5 [print p]
10x10
15x10
10x15
15x15
10x20
15x20

>> for p 3x1 1x2 -1x1 [print p]
3x1
2x1
1x1
3x2
2x2
1x2
```

This implements [CureCode wish #1995](http://issue.cc/r3/1995).
