### PR TITLE
Fix tracing output of PARSE (cc#2150)

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -288,8 +288,10 @@ void Trace_Arg(REBINT num, REBVAL *arg, REBVAL *path)
 {
 	static char tracebuf[64];
 	int depth;
+	int len = MIN(60, limit);
 	CHECK_DEPTH(depth);
-	memcpy(tracebuf, str, MIN(60, limit));
+	memcpy(tracebuf, str, len);
+	tracebuf[len] = '\0';
 	Debug_Fmt(BOOT_STR(RS_TRACE,n), tracebuf);
 }
 


### PR DESCRIPTION
This is a fix to properly zero-terminate strings in the internal `Trace_String` helper used for e.g. tracing output in PARSE.

This fixes [CureCode issue 2150](http://issue.cc/r3/2150).

Fix written by Shixin Zeng: zsx/r3@25d35a946269c6547b1f1091b10753ccc4b91216
