### PR TITLE
FEAT: Initial serial port implementation for POSIX and WIN32

### DIFF
--- a/src/boot/sysobj.r
+++ b/src/boot/sysobj.r
@@ -225,6 +225,10 @@ standard: context [
 		port-id: 80
 			none
 	]
+
+	port-spec-serial: make port-spec-head [
+		speed: 115200
+	]
 	
 	file-info: context [
 		name:

--- a/src/boot/words.r
+++ b/src/boot/words.r
@@ -163,6 +163,7 @@ dns
 tcp
 udp
 clipboard
+serial
 
 ; Gobs:
 gob

--- a/src/core/c-port.c
+++ b/src/core/c-port.c
@@ -628,4 +628,5 @@ SCHEME_ACTIONS *Scheme_Actions;	// Initial Global (not threaded)
 #ifndef MIN_OS
 	Init_Clipboard_Scheme();
 #endif
+	Init_Serial_Scheme();
 }

--- a/src/core/p-serial.c
+++ b/src/core/p-serial.c
@@ -1,0 +1,186 @@
+/***********************************************************************
+**
+**  REBOL [R3] Language Interpreter and Run-time Environment
+**
+**  Copyright 2013 REBOL Technologies
+**  REBOL is a trademark of REBOL Technologies
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**  http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+**
+************************************************************************
+**
+**  Module:  p-serial.c
+**  Summary: serial port interface
+**  Section: ports
+**  Author:  Carl Sassenrath
+**  Notes:
+**
+***********************************************************************/
+
+#include "sys-core.h"
+
+#include "reb-net.h"
+#include "reb-evtypes.h"
+
+
+/***********************************************************************
+**
+*/	static int Serial_Actor(REBVAL *ds, REBSER *port, REBCNT action)
+/*
+***********************************************************************/
+{
+	REBREQ *req;	// IO request
+	REBVAL *spec;	// port spec
+	REBVAL *arg;	// action argument value
+	REBVAL *val;	// e.g. port number value
+	REBINT result;	// IO result
+	REBCNT refs;	// refinement argument flags
+	REBCNT len;		// generic length
+	REBSER *ser;	// simplifier
+	REBVAL *path;
+
+	Validate_Port(port, action);
+
+	*D_RET = *D_ARG(1);
+
+	// Validate PORT fields:
+	spec = OFV(port, STD_PORT_SPEC);
+	if (!IS_OBJECT(spec)) Trap0(RE_INVALID_PORT);
+	path = Obj_Value(spec, STD_PORT_SPEC_HEAD_REF);
+	if (!path) Trap1(RE_INVALID_SPEC, spec);
+
+	//if (!IS_FILE(path)) Trap1(RE_INVALID_SPEC, path);
+
+	req = Use_Port_State(port, RDI_SERIAL, sizeof(*req));
+
+	// Actions for an unopened serial port:
+	if (!IS_OPEN(req)) {
+
+		switch (action) {
+
+		case A_OPEN:
+			arg = Obj_Value(spec, STD_PORT_SPEC_SERIAL_PATH);
+			req->file.path = VAL_DATA(arg);
+			arg = Obj_Value(spec, STD_PORT_SPEC_SERIAL_SPEED);
+			req->file.size = VAL_INT32(arg); // used for baudrate
+			//Secure_Port(SYM_SERIAL, ???, path, ser);
+			if (OS_DO_DEVICE(req, RDC_OPEN)) Trap_Port(RE_CANNOT_OPEN, port, -12);
+			SET_OPEN(req);
+			return R_RET;
+
+		case A_CLOSE:
+			return R_RET;
+
+		case A_OPENQ:
+			return R_FALSE;
+
+		default:
+			Trap_Port(RE_NOT_OPEN, port, -12);
+		}
+	}
+
+	// Actions for an open socket:
+	switch (action) {
+
+	case A_READ:
+		refs = Find_Refines(ds, ALL_READ_REFS);
+
+		// Setup the read buffer (allocate a buffer if needed):
+		arg = OFV(port, STD_PORT_DATA);
+		if (!IS_STRING(arg) && !IS_BINARY(arg)) {
+			Set_Binary(arg, Make_Binary(32000));
+		}
+		ser = VAL_SERIES(arg);
+		req->length = SERIES_AVAIL(ser); // space available
+		if (req->length < 32000/2) Extend_Series(ser, 32000);
+		req->length = SERIES_AVAIL(ser);
+		req->data = STR_TAIL(ser); // write at tail
+		//if (SERIES_TAIL(ser) == 0)
+		req->actual = 0;  // Actual for THIS read, not for total.
+
+		// printf("(max read length %d)", req->length);
+		result = OS_DO_DEVICE(req, RDC_READ); // recv can happen immediately
+		if (result < 0) Trap_Port(RE_READ_ERROR, port, req->error);
+#ifdef DEBUG_SERIAL
+		for (len = 0; len < req->actual; len++) {
+			if (len % 16 == 0) printf("\n");
+			printf("%02x ", req->data[len]);
+		}
+		printf("\n");
+#endif
+		Set_Binary(arg, Copy_Bytes(req->data, req->actual));
+		*D_RET = *arg;
+		return R_RET;
+
+	case A_WRITE:
+		refs = Find_Refines(ds, ALL_WRITE_REFS);
+
+		// Determine length. Clip /PART to size of string if needed.
+		spec = D_ARG(2);
+		len = VAL_LEN(spec);
+		if (refs & AM_WRITE_PART) {
+			REBCNT n = Int32s(D_ARG(ARG_WRITE_LENGTH), 0);
+			if (n <= len) len = n;
+		}
+
+		// Setup the write:
+		*OFV(port, STD_PORT_DATA) = *spec;	// keep it GC safe
+		req->length = len;
+		req->data = VAL_BIN_DATA(spec);
+		req->actual = 0;
+
+		//Print("(write length %d)", len);
+		result = OS_DO_DEVICE(req, RDC_WRITE); // send can happen immediately
+		if (result < 0) Trap_Port(RE_WRITE_ERROR, port, req->error);
+		if (result == DR_DONE) SET_NONE(OFV(port, STD_PORT_DATA));
+		break;
+#if 0
+	case A_UPDATE:
+		// Update the port object after a READ or WRITE operation.
+		// This is normally called by the WAKE-UP function.
+		arg = OFV(port, STD_PORT_DATA);
+		if (req->command == RDC_READ) {
+			if (ANY_BINSTR(arg)) VAL_TAIL(arg) += req->actual;
+		}
+		else if (req->command == RDC_WRITE) {
+			SET_NONE(arg);  // Write is done.
+		}
+		return R_NONE;
+#endif
+	case A_OPENQ:
+		return R_TRUE;
+
+	case A_CLOSE:
+		if (IS_OPEN(req)) {
+			OS_DO_DEVICE(req, RDC_CLOSE);
+			SET_CLOSED(req);
+		}
+		Free_Port_State(port);
+		break;
+
+	default:
+		Trap_Action(REB_PORT, action);
+	}
+
+	return R_RET;
+}
+
+
+/***********************************************************************
+**
+*/	void Init_Serial_Scheme(void)
+/*
+***********************************************************************/
+{
+	Register_Scheme(SYM_SERIAL, 0, Serial_Actor);
+}

--- a/src/include/reb-device.h
+++ b/src/include/reb-device.h
@@ -38,6 +38,7 @@ enum {
 	RDI_NET,
 	RDI_DNS,
 	RDI_CLIPBOARD,
+	RDI_SERIAL,
 	RDI_MAX,
 	RDI_LIMIT = 32
 };

--- a/src/include/reb-device.h
+++ b/src/include/reb-device.h
@@ -179,6 +179,12 @@ struct rebol_devreq {
 			u32  remote_port;		// remote port
 			void *host_info;		// for DNS usage
 		} net;
+		struct {
+			REBCHR *path;			//device path string (in OS local format)
+			i64 baud;				// baud rate of serial port
+			i64 index;				// serial index position
+			void *prior_attr;			// termios: retain previous settings to revert on close
+		} serial;
 	};
 };
 #pragma pack()

--- a/src/mezz/sys-ports.r
+++ b/src/mezz/sys-ports.r
@@ -264,6 +264,20 @@ init-schemes: func [
 		name: 'clipboard
 	]
 
+	make-scheme [
+		title: "Serial Port"
+		name: 'serial
+		spec: system/standard/port-spec-serial
+		init: func [port /local path speed] [
+			if url? port/spec/ref [
+				parse port/spec/ref
+					[thru #":" 0 2 slash copy path [to slash | end] skip copy speed to end]
+				if speed: try [to integer! speed] [port/spec/speed: speed]
+				port/spec/path: to file! path
+			]
+		]
+	]
+
 	system/ports/system:   open [scheme: 'system]
 	system/ports/input:    open [scheme: 'console]
 	system/ports/callback: open [scheme: 'callback]

--- a/src/os/host-device.c
+++ b/src/os/host-device.c
@@ -73,6 +73,7 @@ extern REBDEV Dev_DNS;
 #ifndef MIN_OS
 extern REBDEV Dev_Clipboard;
 #endif
+extern REBDEV Dev_Serial;
 
 REBDEV *Devices[RDI_LIMIT] =
 {
@@ -85,7 +86,10 @@ REBDEV *Devices[RDI_LIMIT] =
 	&Dev_DNS,
 #ifndef MIN_OS
 	&Dev_Clipboard,
+#else
+	0,
 #endif
+	&Dev_Serial,
 	0,
 };
 

--- a/src/os/posix/dev-serial.c
+++ b/src/os/posix/dev-serial.c
@@ -1,0 +1,270 @@
+/***********************************************************************
+**
+**  REBOL [R3] Language Interpreter and Run-time Environment
+**
+**  Copyright 2013 REBOL Technologies
+**  REBOL is a trademark of REBOL Technologies
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**  http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+**
+************************************************************************
+**
+**  Title: Device: Serial port access for Posix
+**  Author: Carl Sassenrath
+**
+************************************************************************
+**
+**  NOTE to PROGRAMMERS:
+**
+**    1. Keep code clear and simple.
+**    2. Document unusual code, reasoning, or gotchas.
+**    3. Use same style for code, vars, indent(4), comments, etc.
+**    4. Keep in mind Linux, OS X, BSD, big/little endian CPUs.
+**    5. Test everything, then test it again.
+**
+***********************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <errno.h>
+#include <termios.h>
+
+#include "reb-host.h"
+#include "host-lib.h"
+
+// Warning: only good for one port, not multiple:
+struct termios prior_attr;
+
+const int speeds[] = {
+	50, B50,
+	75, B75,
+	110, B110,
+	134, B134,
+	150, B150,
+	200, B200,
+	300, B300,
+	600, B600,
+	1200, B1200,
+	1800, B1800,
+	2400, B2400,
+	4800, B4800,
+	9600, B9600,
+	19200, B19200,
+	38400, B38400,
+	57600, B57600,
+	115200, B115200,
+	230400, B230400,
+	0
+};
+
+/***********************************************************************
+**
+**	Local Functions
+**
+***********************************************************************/
+
+int Set_Serial(int ttyfd, int speed)
+{
+	int n;
+	struct termios attr = {};
+
+	// printf("setting attributes: speed %d\n", speed);
+	// Get prior attributes:
+	if (tcgetattr(ttyfd, &prior_attr)) return 1;
+
+	for (n = 0; speeds[n]; n += 2) {
+		if (speed == speeds[n]) {
+			speed = speeds[n+1];
+			break;
+		}
+	}
+	if (speeds[n] == 0) speed = B115200; // invalid, use default
+
+	cfsetospeed (&attr, speed);
+	cfsetispeed (&attr, speed);
+
+	// TTY has many attributes. Refer to "man tcgetattr" for descriptions.
+	// C-flags - control modes:
+	attr.c_cflag |= CREAD | CS8 | CLOCAL;
+
+	// L-flags - local modes:
+	attr.c_lflag = 0; // raw, not ICANON
+
+	// I-flags - input modes:
+	attr.c_iflag |= IGNPAR;
+	
+	// O-flags - output modes:
+	attr.c_oflag = 0;
+
+	// Control characters:
+	// R3 devices are non-blocking (polled for changes):
+	attr.c_cc[VMIN]  = 0;
+	attr.c_cc[VTIME] = 0;
+
+	// Make sure OS queues are empty:
+	tcflush(ttyfd, TCIFLUSH);
+
+	// Set new attributes:
+	if (tcsetattr(ttyfd, TCSANOW, &attr)) return 2;
+
+	return 0;
+}
+
+/***********************************************************************
+**
+*/	DEVICE_CMD Open_Serial(REBREQ *req)
+/*
+**		file.path = the /dev name for the serial port
+**		file.length = speed (baudrate)
+**
+***********************************************************************/
+{
+	char *path;
+	char devpath[128];
+	int h;
+
+	if (!(path = req->file.path)) {
+		req->error = -RFE_BAD_PATH;
+		return DR_ERROR;
+	}
+
+	strcpy(&devpath[0], "/dev/");
+	strncpy(&devpath[5], path, 128-6);
+	h = open(&devpath[0], O_RDWR | O_NOCTTY | O_NONBLOCK);
+	if (h < 0) {
+		req->error = -RFE_OPEN_FAIL;
+		return DR_ERROR;
+	}
+
+	if (Set_Serial(h, req->file.size)) {
+		close(h);
+		req->error = -RFE_OPEN_FAIL;
+		return DR_ERROR;
+	}		
+
+	req->id = h;
+	return DR_DONE;
+}
+
+
+/***********************************************************************
+**
+*/	DEVICE_CMD Close_Serial(REBREQ *req)
+/*
+***********************************************************************/
+{
+	if (req->id) {
+		tcsetattr(req->id, TCSANOW, &prior_attr);
+		close(req->id);
+		req->id = 0;
+	}
+	return DR_DONE;
+}
+
+
+/***********************************************************************
+**
+*/	DEVICE_CMD Read_Serial(REBREQ *req)
+/*
+***********************************************************************/
+{
+	if (!req->id) {
+		req->error = -RFE_NO_HANDLE;
+		return DR_ERROR;
+	}
+
+	req->actual = read(req->id, req->data, req->length);
+	//printf("read %d ret: %d\n", req->length, req->actual);
+	if (req->actual < 0) {
+		req->error = -RFE_BAD_READ;
+		return DR_ERROR;
+	} else {
+		req->file.index += req->actual;
+	}
+
+	return DR_DONE;
+}
+
+
+/***********************************************************************
+**
+*/	DEVICE_CMD Write_Serial(REBREQ *req)
+/*
+***********************************************************************/
+{
+	if (!req->id) {
+		req->error = -RFE_NO_HANDLE;
+		return DR_ERROR;
+	}
+
+	if (req->length == 0) return DR_DONE;
+
+	req->actual = write(req->id, req->data, req->length);
+	//printf("write %d ret: %d\n", req->length, req->actual);
+	if (req->actual < 0) {
+		req->error = -RFE_BAD_WRITE;
+		return DR_ERROR;
+	}
+
+	return DR_DONE;
+}
+
+
+/***********************************************************************
+**
+*/	DEVICE_CMD Query_Serial(REBREQ *req)
+/*
+***********************************************************************/
+{
+#if 0
+	struct pollfd pfd;
+
+	if (req->id) {
+		pfd.fd = req->id;
+		pfd.events = POLLIN;
+		n = poll(&pfd, 1, 0);
+	}
+#endif
+	return DR_DONE;
+}
+
+
+/***********************************************************************
+**
+**	Command Dispatch Table (RDC_ enum order)
+**
+***********************************************************************/
+
+static DEVICE_CMD_FUNC Dev_Cmds[RDC_MAX] = {
+	0,
+	0,
+	Open_Serial,
+	Close_Serial,
+	Read_Serial,
+	Write_Serial,
+	0,  // poll
+	0,	// connect
+	Query_Serial,
+	0,	// modify
+	0,	// create
+	0,	// delete
+	0	// rename
+};
+
+DEFINE_DEV(Dev_Serial, "Serial IO", 1, Dev_Cmds, RDC_MAX, sizeof(REBREQ));
+

--- a/src/tools/file-base.r
+++ b/src/tools/file-base.r
@@ -63,6 +63,7 @@ core: [
 	p-event.c
 	p-file.c
 	p-net.c
+	p-serial.c
 	s-cases.c
 	s-crc.c
 	s-file.c
@@ -149,6 +150,7 @@ os-posix: [
 	dev-stdio.c
 	dev-event.c
 	dev-file.c
+	dev-serial.c
 ]
 
 boot-files: [

--- a/src/tools/file-base.r
+++ b/src/tools/file-base.r
@@ -134,6 +134,7 @@ os-win32: [
 	dev-file.c
 	dev-event.c
 	dev-clipboard.c
+	dev-serial.c
 ]
 
 os-win32g: [


### PR DESCRIPTION
# Serial Implementation

This pull request includes two commits:
- The first commit is Carl's serial code implementation from the ReCode conference.
- The second commit contains the extensions that I have made to it which include:
  -Win32 Implementation
  -Ability to properly open and close more than one serial port (With the REBREQ Union change)
  -Made a few changes to match style of the rest of repository as far as I can tell
## Notes
- For non-posix or win32 systems this will not compile.  I was advised not to add a bunch of ifdefs in lieu of creating stub files for the dev-serial.c when we come across them.  I do not have the ability to test other systems
- I have tested extensively on Linux & Win32 without any issues.  Need someone to test on OS X
## Usage

```
serial-port: open serial://ttyS1/19200
```

Then, read/write binary. Keep in mind it's buffered only by the OS itself, so for long reads, you'll want to do the buffering yourself:

```
response: make binary! 1000
while [not empty? buf: read serial-port][
    append response buf
    wait .2
]
```
