### PR TITLE
Fix crash due to missing type check for TRY/except handlers (cc#1514)

### DIFF
--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -737,17 +737,17 @@ got_err:
 /*
 ***********************************************************************/
 {
-	REBVAL value = *D_ARG(3); // TRY exception will trim the stack
 	REBFLG except = D_REF(2);
+	REBVAL handler = *D_ARG(3); // TRY exception will trim the stack
 
 	if (Try_Block(VAL_SERIES(D_ARG(1)), VAL_INDEX(D_ARG(1)))) {
 		if (except) {
-			if (IS_BLOCK(&value)) {
-				DO_BLK(&value);
+			if (IS_BLOCK(&handler)) {
+				DO_BLK(&handler);
 			}
-			else { // do func[error] arg
-				REBVAL arg = *DS_NEXT; // will get overwritten
-				Apply_Func(0, &value, &arg, 0);
+			else { // do func[err] error
+				REBVAL error = *DS_NEXT; // will get overwritten
+				Apply_Func(0, &handler, &error, 0);
 			}
 		}
 	}

--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -747,6 +747,14 @@ got_err:
 			}
 			else { // do func[err] error
 				REBVAL error = *DS_NEXT; // will get overwritten
+				REBVAL *args = BLK_SKIP(VAL_FUNC_ARGS(&handler), 1);
+				if (NOT_END(args) && !TYPE_CHECK(args, VAL_TYPE(&error))) {
+					// TODO: This results in an error message such as "action!
+					// does not allow error! for its value1 argument". A better
+					// message would be more like "except handler does not
+					// allow error! for its value1 argument."
+					Trap3(RE_EXPECT_ARG, Of_Type(&handler), args, Of_Type(&error));
+				}
 				Apply_Func(0, &handler, &error, 0);
 			}
 		}


### PR DESCRIPTION
With this change, TRY/except now checks that the typespec of a handler function actually allows calls with the error value, before calling the handler function.

This fixes [CureCode issue #1514](http://issue.cc/r3/1514).
