### PR TITLE
Restore Saved_State/Halt_State when a longjmp happens

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -1055,9 +1055,12 @@ eval_func2:
 {
 	REBOL_STATE state;
 	REBVAL *tos;
+	jmp_buf *Last_Halt_State = Halt_State;
 
 	PUSH_STATE(state, Saved_State);
 	if (SET_JUMP(state)) {
+		/* Halt_State might become invalid, restore the one above */
+		Halt_State = Last_Halt_State;
 		POP_STATE(state, Saved_State);
 		Catch_Error(DS_NEXT); // Stores error value here
 		return TRUE;
@@ -1623,6 +1626,7 @@ eval_func2:
 {
 	REBOL_STATE state;
 	REBVAL *val;
+	jmp_buf *Last_Saved_State = Saved_State;
 //	static D = 0;
 //	int depth = D++;
 
@@ -1631,6 +1635,8 @@ eval_func2:
 	PUSH_STATE(state, Halt_State);
 	if (SET_JUMP(state)) {
 //		Debug_Fmt("Throw Halt %d", depth);
+		/* Saved_State might become invalid, restore the one above */
+		Saved_State = Last_Saved_State;
 		POP_STATE(state, Halt_State);
 		Catch_Error(DS_NEXT); // Stores error value here
 		return TRUE;


### PR DESCRIPTION
This fixes [CC#2190](http://issue.cc/r3/2190), which is illustrated by:

```
attempt [; this sets Saved_State
    catch/quit [ ;this calls Try_Block_Halt and sets Halt_State
        print x ; this causes an error, and calls
            ;"longjmp(*State_State)", which invalidates
            ; Halt_State above.
    ]
]
load %./ ;Just tries to fill up the C stack and messes up "Halt_State".
halt ; Jumps to the invalid "Halt_State", and crashes
```

or

```
catch/quit [ ;sets Halt_State
    attempt [ ;sets Saved_State
        quit ; jumps to Halt_State, and invalidates "Saved_State"
    ]
]
print x ; Causes a jump to the invalid "Saved_State"
```
