### PR TITLE
Make Halt_State a proper global

### DIFF
--- a/src/core/b-init.c
+++ b/src/core/b-init.c
@@ -899,6 +899,7 @@ static REBCNT Set_Option_Word(REBCHR *str, REBCNT field)
 	PG_Mem_Usage = 0;
 	PG_Mem_Limit = 0;
 	PG_Reb_Stats = Make_Mem(sizeof(*PG_Reb_Stats));
+	Halt_State = 0;
 	Reb_Opts = Make_Mem(sizeof(*Reb_Opts));
 
 	// Thread locals:

--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -50,8 +50,6 @@ enum Eval_Types {
 	ET_END			// end of block
 };
 
-static jmp_buf *Halt_State = 0;  //!!!!!!!!!! global?
-
 /*
 void T_Error(REBCNT n) {;}
 

--- a/src/include/sys-globals.h
+++ b/src/include/sys-globals.h
@@ -58,6 +58,8 @@ PVAR REBI64 PG_Boot_Time;	// Counter when boot started
 PVAR REBINT Current_Year;
 PVAR REB_OPTS *Reb_Opts;
 
+PVAR jmp_buf *Halt_State;	// Pointer to saved CPU state for HALT/QUIT handlers
+
 // This signal word should be thread-local, but it will not work
 // when implemented that way. Needs research!!!!
 PVAR REBCNT	Eval_Signals;	// Signal flags
@@ -93,7 +95,7 @@ TVAR REBVAL	*DS_Base;		// Data stack base
 TVAR REBINT	DSP;			// Data stack pointer
 TVAR REBINT	DSF;			// Data stack frame (function base)
 
-TVAR jmp_buf *Saved_State;	// Pointer to saved CPU state
+TVAR jmp_buf *Saved_State;	// Pointer to saved CPU state for error handlers.
 
 //-- Evaluation variables:
 TVAR REBI64	Eval_Cycles;	// Total evaluation counter (upward)


### PR DESCRIPTION
There's is a [comment on Halt_State](https://github.com/rebol/rebol/blob/25033f897b2bd466068d7663563cd3ff64740b94/src/core/c-do.c#L53) which says:

```
static jmp_buf *Halt_State = 0;  //!!!!!!!!!! global?
```

Ten exclamation points and one question mark indicates it's not too surprising that when trying to do some integration with Rebol on a project, this was a problem.  I worked around the problem I had by taking off the `static` and that was enough for what I needed, so I originally submitted this PR for that.  @earl suggested fixing it properly, as he has a better idea of what the multithreading story is.  So I replaced my commit with his.

I tested his change and it worked for my case.  I don't know that this is the kind of thing that's really tested fully by any automated tests... nothing hits Ctrl-C to cancel a running evaluation but direct user interaction.

**Note: This is an important one to integrate for something I'm working on that links with Rebol.**

_(And it means 10 fewer exclamation points and one fewer question mark in the code.)_
