### PR TITLE
Correct sequence point issue in t-object.c

### DIFF
--- a/src/core/t-object.c
+++ b/src/core/t-object.c
@@ -423,7 +423,8 @@ static REBSER *Trim_Object(REBSER *obj)
 			if (IS_DATATYPE(arg)) types |= TYPESET(VAL_DATATYPE(arg));
 			else types |= VAL_TYPESET(arg);
 		}
-		VAL_OBJ_FRAME(value) = obj = Copy_Block(VAL_OBJ_FRAME(value), 0);
+		obj = Copy_Block(VAL_OBJ_FRAME(value), 0);
+		VAL_OBJ_FRAME(value) = obj;
 		if (types != 0) Copy_Deep_Values(obj, 1, SERIES_TAIL(obj), types);
 		break; // returns value
 	}


### PR DESCRIPTION
Correcting these issues on a case-by-case basis is not the right way to do it (I discussed a strategy for using compiler checks in #230).  But I just spotted this one while reading.

```
VAL_OBJ_FRAME(value) = obj = Copy_Block(VAL_OBJ_FRAME(value), 0);
```

`=` is not a sequence point in C/C++.  (Unless it's an operator overload in C++, in which case it's syntax on top of a function call, which is a sequence point.)

You might think it would be worth it for compiler authors to declare = as a sequence point, so that such constructs would be guaranteed to evaluate `Copy_Block(VAL_OBJ_FRAME(value), 0)` before assigning `obj` to `VAL_OBJ_FRAME(value)`.  It doesn't work that way for a reason:

http://stackoverflow.com/questions/4362501/any-good-reason-why-assignment-operator-isnt-a-sequence-point

So what _could_ happen here is that the previous value of `obj` is assigned to `VAL_OBJ_FRAME(value)`.  Then obj gets the Copy_Block result, which is not put into `VAL_OBJ_FRAME(value)`.  :-/  It's up for grabs what the compiler will do.

http://www.ganssle.com/rants/sequencepoints.htm

_"While it's easy to brush C off as a super-assembly language it's actually quite rich, expressive and has some dark holes that elude too many developers. Indeed, the C99 standard is over 500 pages long, is rather cryptic, and reading it is a sure cure for the worst case of insomnia."_
