### PR TITLE
Add Expand_Frame call to Bind_Block_Words

### DIFF
--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -829,7 +829,7 @@
 			else {
 				// Word is not in frame. Add it if option is specified:
 				if ((mode & BIND_ALL) || ((mode & BIND_SET) && (IS_SET_WORD(value)))) {
-					Expand_Frame(obj, 1, 1);
+					Expand_Frame(frame, 1, 1);
 					Append_Frame(frame, value, 0);
 					binds[VAL_WORD_CANON(value)] = VAL_WORD_INDEX(value);
 				}

--- a/src/core/c-frame.c
+++ b/src/core/c-frame.c
@@ -829,6 +829,7 @@
 			else {
 				// Word is not in frame. Add it if option is specified:
 				if ((mode & BIND_ALL) || ((mode & BIND_SET) && (IS_SET_WORD(value)))) {
+					Expand_Frame(obj, 1, 1);
 					Append_Frame(frame, value, 0);
 					binds[VAL_WORD_CANON(value)] = VAL_WORD_INDEX(value);
 				}


### PR DESCRIPTION
I noticed very sketchy behavior of COPY when it was applied to the user context (or really, any object that had been used for binding).

If you want to see the carnage, just try:

```
>> ctx1: bind? 'print
>> ctx2: copy ctx1
>> ctx1/testing: "This 'testing' will appear in ctx2, and it's of type END!"
>> probe ctx2
```

In my brief diagnosis of the issue, I noticed that `append ctx1 'testing` did not have the same problem.  So something about the implementation of appending fields to objects didn't introduce the "copy frailty" that binding had.

What I noticed about other calls to Append_Frame was that they had associated Expand_Frame calls.  I blindly added that call to Bind_Block_Words, and it gave the appearance of correcting the problem.

I submit it as a talking point for whatever the real solution might be.
