### PR TITLE
Set local-lib to refer to the local import library

### DIFF
--- a/src/mezz/sys-base.r
+++ b/src/mezz/sys-base.r
@@ -129,6 +129,7 @@ make-module*: func [
 	if find spec/options 'extension [
 		append obj 'lib-base ; specific runtime values MUST BE FIRST
 	]
+	append obj 'local-lib ; local import library for the module
 
 	unless spec/type [spec/type: 'module] ; in case not set earlier
 
@@ -180,6 +181,7 @@ make-module*: func [
 	]
 
 	bind body obj
+	obj/local-lib: any [mixins make object! 0] ; always set, always overrides
 	if block? hidden [protect/hide/words hidden]
 	obj: to module! reduce [spec obj]
 	do body

--- a/src/mezz/sys-start.r
+++ b/src/mezz/sys-start.r
@@ -120,7 +120,7 @@ start: func [
 
 	;-- Make the user's global context:
 	tmp: make object! 320
-	append tmp reduce ['system :system]
+	append tmp reduce ['system :system 'local-lib :tmp]
 	system/contexts/user: tmp
 
 	;boot-print ["Checking for user.r file in" file]


### PR DESCRIPTION
Instead of having the local import library object have no referent once the module is running except the words you bound from it, set the word `local-lib` in the module context to refer to it. This will let the developer control overrides, just like `lib` does globally.

Also set `local-lib` to `system/contexts/user` in the script context. Even though there is nothing for scripts like the object target of local imports in modules, presetting the word will prevent it from being a problem when modules unnecessarily export it, and it will serve as a shortcut way to refer to the context, like `lib`.

See http://issue.cc/r3/2116 for details.
