### PR TITLE
Fix: make-make.r broken for Amiga target

### DIFF
--- a/src/tools/make-make.r
+++ b/src/tools/make-make.r
@@ -389,7 +389,7 @@ macro++ RAPI_FLAGS compile-flags
 macro++ HOST_FLAGS make compile-flags [PIC: NCM: none]
 macro+  HOST_FLAGS compile-flags/f64 ; default for all
 
-if flag? +SC [remove find fb/os-specific-objs 'host-readline.c]
+if flag? +SC [remove find os-specific-objs 'host-readline.c]
 
 emit makefile-head
 emit ["OBJS =" tab]


### PR DESCRIPTION
Running make-make.r with target 0.1.03 currently errors out in Rebol.   Haven't been able to test the rest of the compilation, but with this change the makefile is generated.
