### PR TITLE
Ensure proper path component types during refinement processing

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -739,8 +739,10 @@ more_path:
 	}
 
 	// Hack to process remaining path:
-	if (path && NOT_END(path)) goto more_path;
-	//	Trap2(RE_NO_REFINE, Func_Word(dsf), path);
+	if (path && NOT_END(path)) {
+		if (!IS_WORD(path)) Trap1(RE_BAD_REFINE, path);
+		goto more_path;
+	}
 
 	return index;
 }


### PR DESCRIPTION
A self-declared refinement processing "hack" fails, in certain
situations, to re-verify that path components accessed in refinement
processing are words before using word-specific accessor functions on
them.

Without this fix (example as reported by Sunanda in CC#1977):

```
>> a: func [/b] [1]

>> a/b/%
;; R3 crashes at this point.
```

With this fix:

```
>> a/b/%
** Script error: incompatible refinement: %""
```

This patch is a slight variation of an earlier fix written by Shixin
Zeng (zsx/r3@72b5d98).

This fixes CureCode issue #1977.
