### PR TITLE
Trap evaluation attemps of ET_INVALID values

### DIFF
--- a/src/core/c-do.c
+++ b/src/core/c-do.c
@@ -962,6 +962,10 @@ eval_func2:
 	case ET_END:
 		 return END_FLAG;
 
+	case ET_INVALID:
+		 Trap1(RE_NO_VALUE, value);
+		 break;
+
 	default:
 		//Debug_Fmt("Bad eval: %d %s", VAL_TYPE(value), Get_Type_Name(value));
 		Crash(RP_BAD_EVALTYPE, VAL_TYPE(value));


### PR DESCRIPTION
Without this commit:

```
>> reduce reduce [:self]
REBOL system error #1101
Program terminated abnormally
This should never happen
```

With this commit:

```
>> reduce reduce [:self]
** Script error: frame! has no value
** Where: reduce
** Near: reduce reduce [:self]
```

This fixes CureCode issue #1756.

---

(This pull request is just a cherry-picking of Shixin Zeng's zsx/r3@b2757879834d47ae5288f4f1050e8b74a8029bfc for easier upstreaming.)
