### PR TITLE
Fix unwind-passing in SWITCH/all (CC#2242)

### DIFF
--- a/src/core/n-control.c
+++ b/src/core/n-control.c
@@ -718,7 +718,7 @@ got_err:
 			// Evaluate the case block
 			result = DO_BLK(blk);
 			if (!all) return R_TOS1;
-			if (THROWN(result) && Check_Error(result) >= 0) break;
+			if (THROWN(result)) return R_TOS1;
 		}
 	}
 


### PR DESCRIPTION
SWITCH correctly passes unwinds along (because it exits early, right
after the first DO_BLK), but SWITCH/all swallows unwinds. This fixes
the /all case, to pass unwinds along properly.

We still leave the THROWN check to after the /all check in a (most
likely misguided) attempt to micro-optimise for the arguably more common
non-/all case.
